### PR TITLE
Merge upstream branch main into branch commonmark

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,15 @@
 # Changes
 
+## 2.22.0
+
+Development:
+
+- Add support for TeX math surrounded by backslash-escaped
+  parens and brackets. (contributed by @lostenderman, #61,
+  #235, #236, #270)
+- Add support for attributes on links, images, and inline
+  code spans. (jgm#36, jgm#43, #50, #123, #256, #280)
+
 ## 2.21.0 (2022-02-28)
 
 Development:

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,8 @@ GITHUB_PAGES=gh-pages
 VERSION=$(shell git describe --tags --always --long --exclude latest)
 LASTMODIFIED=$(shell git log -1 --date=format:%Y-%m-%d --format=%ad)
 
+PANDOC_INPUT_FORMAT=markdown+tex_math_single_backslash+tex_math_double_backslash-raw_tex
+
 # This is the default pseudo-target. It typesets the manual,
 # the examples, and extracts the package files.
 all: $(MAKEABLES)
@@ -127,7 +129,7 @@ examples/example.tex: force
 	    -e 's#\\mdef{\([^}]*\)}#`\\\1`#g' \
 	    -e 's#\\mref{\([^}]*\)}#`\\\1`#g' \
 	| \
-	pandoc -f markdown-raw_tex -t html -N -s --toc --toc-depth=3 --css=$(word 2, $^) >$@
+	pandoc -f $(PANDOC_INPUT_FORMAT) -t html -N -s --toc --toc-depth=3 --css=$(word 2, $^) >$@
 
 # This pseudo-target runs all the tests in the `tests/` directory.
 test:

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -23,7 +23,10 @@ LUACLI_OPTIONS=\
   subscripts=true \
   superscripts=true \
   tableCaptions=true \
-  taskLists=true
+  taskLists=true \
+  texMathDollars=true \
+  texMathDoubleBackslash=true \
+  texMathSingleBackslash=true
 OUTPUT=context-mkii.pdf context-mkiv.pdf latex-pdftex.pdf \
   latex-luatex.pdf latex-tex4ht.html latex-tex4ht.css
 

--- a/examples/context-mkii.tex
+++ b/examples/context-mkii.tex
@@ -27,6 +27,8 @@
     tableCaptions = yes,
     taskLists = yes,
     texMathDollars = yes,
+    texMathDoubleBackslash = yes,
+    texMathSingleBackslash = yes,
   ]
 
 % Set renderers of the Markdown module.

--- a/examples/context-mkiv.tex
+++ b/examples/context-mkiv.tex
@@ -27,6 +27,8 @@
     tableCaptions = yes,
     taskLists = yes,
     texMathDollars = yes,
+    texMathDoubleBackslash = yes,
+    texMathSingleBackslash = yes,
   ]
 
 % Set renderers of the Markdown module.

--- a/examples/example.md
+++ b/examples/example.md
@@ -177,3 +177,21 @@ $$ x^n + y^n = z^n $$
 | even
   discontinuous
 | lines
+
+This is inline and display TeX math created using dollars signs:
+
+$E=mc^2$
+
+$$E=mc^2$$
+
+This is inline and display TeX math created using single backslashes:
+
+\(E=mc^2\)
+
+\[E=mc^2\]
+
+This is inline and display TeX math created using double backslashes:
+
+\\(E=mc^2\\)
+
+\\[E=mc^2\\]

--- a/examples/latex.tex
+++ b/examples/latex.tex
@@ -35,6 +35,8 @@
   tableCaptions,
   taskLists,
   texMathDollars,
+  texMathDoubleBackslash,
+  texMathSingleBackslash,
 ]{markdown}
 \begin{markdown*}{hybrid}
 ---

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -1307,13 +1307,19 @@ end)()
 %     is used in the `witiko/graphicx/http` \LaTeX{} theme, see Section
 %     <#sec:latexthemes>.
 %
+% \pkg{graphicx}
+%
+%:    A package that builds upon the \pkg{graphics} package, which is part of
+%     the \LaTeXe{} kernel. It provides a key-value interface that is used in
+%     the default renderer prototypes for image attribute contexts.
+%
 % \pkg{grffile}
 %
-%:    A package that extends the name processing of package graphics to support
-%     a larger range of file names in $2006\leq{}$\TeX{} Live${}\leq{}2019$.
-%     Since \TeX{} Live${}\geq{}2020$, the functionality of the package has
-%     been integrated in the \LaTeXe{} kernel. It is used in the `witiko/dot`
-%     and `witiko/graphicx/http` \LaTeX{} themes, see Section
+%:    A package that extends the name processing of the \pkg{graphics} package
+%     to support a larger range of file names in $2006\leq{}$\TeX{}
+%     Live${}\leq{}2019$.  Since \TeX{} Live${}\geq{}2020$, the functionality
+%     of the package has been integrated in the \LaTeXe{} kernel. It is used in
+%     the `witiko/dot` and `witiko/graphicx/http` \LaTeX{} themes, see Section
 %     <#sec:latexthemes>.
 %
 % \pkg{etoolbox}
@@ -4393,11 +4399,11 @@ defaultOptions.codeSpans = true
 %
 :    true
 
-     :   Enable the
-%        iA\,Writer content blocks syntax extension~[@sotkov17]:
-%        \iffalse
-         iA\,Writer content blocks syntax extension:
-%        \fi
+     :  Enable the
+%       iA\,Writer content blocks syntax extension~[@sotkov17]:
+%       \iffalse
+        iA\,Writer content blocks syntax extension:
+%       \fi
 
         ``` md
         http://example.com/minard.jpg (Napoleon's
@@ -4410,8 +4416,8 @@ defaultOptions.codeSpans = true
 
 :    false
 
-     :   Disable the
-         iA\,Writer content blocks syntax extension.
+     :  Disable the
+        iA\,Writer content blocks syntax extension.
 
 % \end{markdown}
 % \iffalse
@@ -6126,20 +6132,20 @@ defaultOptions.hashEnumerators = false
 %
 :    true
 
-     :   Enable the assignment of HTML attributes to headings:
+     :  Enable the assignment of HTML attributes to headings:
 
-         ``` md
-         # My first heading {#foo}
+        ``` md
+        # My first heading {#foo}
 
-         ## My second heading ##    {#bar .baz}
+        ## My second heading ##    {#bar .baz}
 
-         Yet another heading   {key=value}
-         ===================
-         ``````
+        Yet another heading   {key=value}
+        ===================
+        ``````
 
 :    false
 
-     :   Disable the assignment of HTML attributes to headings.
+     :  Disable the assignment of HTML attributes to headings.
 
 % \end{markdown}
 % \iffalse
@@ -6649,6 +6655,100 @@ defaultOptions.hybrid = false
 %</lua,lua-cli>
 %<*manual-options>
 
+#### Option `inlineCodeAttributes`
+
+`inlineCodeAttributes` (default value: `false`)
+
+% \fi
+% \begin{markdown}
+%
+% \Optitem[false]{inlineCodeAttributes}{\opt{true}, \opt{false}}
+%
+:    true
+
+     :  Enable the Pandoc inline code span attribute extension:
+
+        ``` md
+        `<$>`{.haskell}
+        ``````
+
+:    false
+
+     :  Enable the Pandoc inline code span attribute extension.
+
+% \end{markdown}
+% \iffalse
+
+##### \LaTeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+```` tex
+\documentclass{article}
+\usepackage[inlineCodeAttributes]{markdown}
+\usepackage{expl3}
+\ExplSyntaxOn
+\markdownSetup{
+  renderers = {
+    codeSpanAttributeContextBegin = {
+      \group_begin:
+      \color_group_begin:
+      \markdownSetup{
+        renderers = {
+          attributeKeyValue = {
+            \str_if_eq:nnT
+              { ##1 }
+              { color }
+              {
+                 \color_select:n { ##2 }
+              }
+          },
+        },
+      }
+    },
+    codeSpanAttributeContextEnd = {
+      \color_group_end:
+      \group_end:
+    },
+  },
+}
+\ExplSyntaxOff
+\begin{document}
+\begin{markdown}
+Here is some `colored text`{color=red}.
+\end{markdown}
+\end{document}
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+lualatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> Here is some <span style="color: red">`colored text`</span>.
+
+%</manual-options>
+%<*tex>
+% \fi
+%  \begin{macrocode}
+\@@_add_lua_option:nnn
+  { inlineCodeAttributes }
+  { boolean }
+  { false }
+%    \end{macrocode}
+% \iffalse
+%</tex>
+%<*lua,lua-cli>
+% \fi
+%  \begin{macrocode}
+defaultOptions.inlineCodeAttributes = false
+%    \end{macrocode}
+% \par
+% \iffalse
+%</lua,lua-cli>
+%<*manual-options>
+
 #### Option `inlineNotes`
 
 `inlineNotes` (default value: `false`)
@@ -6923,6 +7023,100 @@ defaultOptions.jekyllData = false
 %</lua,lua-cli>
 %<*manual-options>
 
+#### Option `linkAttributes`
+
+`linkAttributes` (default value: `false`)
+
+% \fi
+% \begin{markdown}
+%
+% \Optitem[false]{linkAttributes}{\opt{true}, \opt{false}}
+%
+:    true
+
+     :  Enable the Pandoc link and image attribute extension:
+
+        ``` md
+        An inline ![image](foo.jpg){#id .class width=30 height=20px}
+        and a reference ![image][ref] with attributes.
+
+        [ref]: foo.jpg "optional title" {#id .class key=val key2="val 2"}
+        ``````
+
+:    false
+
+     :  Enable the Pandoc link and image attribute extension.
+
+% \end{markdown}
+% \iffalse
+
+##### \LaTeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+```` tex
+\documentclass{article}
+\usepackage[linkAttributes]{markdown}
+\usepackage{expl3, graphicx}
+\ExplSyntaxOn
+\markdownSetup{
+  renderers = {
+    imageAttributeContextBegin = {
+      \group_begin:
+      \markdownSetup{
+        renderers = {
+          attributeKeyValue = {
+            \setkeys
+              { Gin }
+              { { ##1 } = { ##2 } }
+          },
+        },
+      }
+    },
+    imageAttributeContextEnd = {
+      \group_end:
+    },
+  },
+}
+\ExplSyntaxOff
+\begin{document}
+\begin{markdown}
+Here is an example image:
+
+ ![example image](example-image){width=5cm height=4cm}
+\end{markdown}
+\end{document}
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+lualatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain an example
+image (from [Martin Scharrer's mwe package][mwe]) displayed at size 5cm × 4cm.
+
+ [mwe]: https://ctan.org/pkg/mwe (mwe – Packages and image files for MWEs)
+
+%</manual-options>
+%<*tex>
+% \fi
+%  \begin{macrocode}
+\@@_add_lua_option:nnn
+  { linkAttributes }
+  { boolean }
+  { false }
+%    \end{macrocode}
+% \iffalse
+%</tex>
+%<*lua,lua-cli>
+% \fi
+%  \begin{macrocode}
+defaultOptions.linkAttributes = false
+%    \end{macrocode}
+% \par
+% \iffalse
+%</lua,lua-cli>
+%<*manual-options>
+
 #### Option `lineBlocks`
 
 `lineBlocks` (default value: `false`)
@@ -6934,7 +7128,7 @@ defaultOptions.jekyllData = false
 %
 :    true
 
-     :  Enable the Pandoc line block syntax extension.
+     :  Enable the Pandoc line block syntax extension:
 
         ``` md
         | this is a line block that
@@ -6946,7 +7140,7 @@ defaultOptions.jekyllData = false
 
 :    false
 
-     :   Disable the Pandoc line block syntax extension.
+     :  Disable the Pandoc line block syntax extension.
 
 % \end{markdown}
 % \iffalse
@@ -7090,7 +7284,7 @@ defaultOptions.lineBlocks = false
 
 :    false
 
-     :    Disable the Pandoc note syntax extension.
+     :  Disable the Pandoc note syntax extension.
 
 % \end{markdown}
 % \iffalse
@@ -8276,15 +8470,15 @@ defaultOptions.startNumber = true
 %
 :    true
 
-     :   Enable the Pandoc strike-through syntax extension:
+     :  Enable the Pandoc strike-through syntax extension:
 
-         ``` md
-         This ~~is deleted text.~~
-         ``````
+        ``` md
+        This ~~is deleted text.~~
+        ``````
 
 :    false
 
-     :   Disable the Pandoc strike-through syntax extension.
+     :  Disable the Pandoc strike-through syntax extension.
 
 % \end{markdown}
 % \iffalse
@@ -8508,15 +8702,15 @@ defaultOptions.stripIndent = false
 %
 :    true
 
-     :   Enable the Pandoc subscript syntax extension:
+     :  Enable the Pandoc subscript syntax extension:
 
-         ``` md
-         H~2~O is a liquid.
-         ``````
+        ``` md
+        H~2~O is a liquid.
+        ``````
 
 :    false
 
-     :   Disable the Pandoc subscript syntax extension.
+     :  Disable the Pandoc subscript syntax extension.
 
 % \end{markdown}
 % \iffalse
@@ -8597,15 +8791,15 @@ defaultOptions.subscripts = false
 %
 :    true
 
-     :   Enable the Pandoc superscript syntax extension:
+     :  Enable the Pandoc superscript syntax extension:
 
-         ``` md
-         2^10^ is 1024.
-         ``````
+        ``` md
+        2^10^ is 1024.
+        ``````
 
 :    false
 
-     :   Disable the Pandoc superscript syntax extension.
+     :  Disable the Pandoc superscript syntax extension.
 
 % \end{markdown}
 % \iffalse
@@ -8686,11 +8880,11 @@ defaultOptions.superscripts = false
 %
 :    true
 
-     :   Enable the Pandoc `table_captions` syntax extension for
-%        pipe tables (see the \Opt{pipeTables} option).
-%        \iffalse
-         [pipe tables](#pipe-tables).
-%        \fi
+     :  Enable the Pandoc `table_captions` syntax extension for
+%       pipe tables (see the \Opt{pipeTables} option).
+%       \iffalse
+        [pipe tables](#pipe-tables).
+%       \fi
 
         ``` md
         | Right | Left | Default | Center |
@@ -8813,7 +9007,7 @@ defaultOptions.tableCaptions = false
 %
 :    true
 
-     :   Enable the Pandoc `task_lists` syntax extension.
+     :  Enable the Pandoc `task_lists` syntax extension:
 
 
         ``` md
@@ -9039,9 +9233,9 @@ defaultOptions.texComments = false
 %
 :    true
 
-     :  Enable the Pandoc `tex_math_dollars` syntax extension.
+     :  Enable the Pandoc `tex_math_dollars` syntax extension:
 
-        ```
+        ``` md
         inline math: $E=mc^2$
 
         display math: $$E=mc^2$$
@@ -9228,6 +9422,406 @@ defaultOptions.texMathDollars = false
 %</lua,lua-cli>
 %<*manual-options>
 
+#### Option `texMathDoubleBackslash`
+
+`texMathDoubleBackslash` (default value: `false`)
+
+% \fi
+% \begin{markdown}
+%
+% \Optitem[false]{texMathDoubleBackslash}{\opt{true}, \opt{false}}
+%
+:    true
+
+     :  Enable the Pandoc `tex_math_double_backslash` syntax extension:
+
+        ``` md
+        inline math: \\(E=mc^2\\)
+
+        display math: \\[E=mc^2\\]
+        ```
+
+:    false
+
+     :  Disable the Pandoc `tex_math_double_backslash` syntax extension.
+
+% \end{markdown}
+% \iffalse
+
+##### Lua Module Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\input markdown
+\input lmfonts
+\directlua{
+  local markdown = require("markdown")
+  local newline = [[^^J^^J]]
+  local convert = markdown.new({texMathDoubleBackslash = true})
+  local input =
+    [[\\(E=mc^2\\)]] .. newline .. newline ..
+    [[\\[\hat{f} \left ( \xi  \right )= \int_{-\infty}^{\infty} f\left ( x  \right ) e^{-i2\pi \xi x} dx\\]]]
+  tex.sprint(convert(input)) }
+\bye
+```````
+Then, invoke LuaTeX from the terminal:
+``` sh
+luatex document.tex
+```````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> \\(E=mc^2\\)
+>
+> \\[\hat{f} \left ( \xi  \right )= \int_{-\infty}^{\infty} f\left ( x  \right ) e^{-i2\pi \xi x} dx\\]
+
+##### Lua CLI Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\input markdown
+\input lmfonts
+\input optionfalse
+\par
+\input optiontrue
+\bye
+```````
+Using a text editor, create a text document named `content.md` with the
+following content:
+``` md
+\\(E=mc^2\\)
+
+\\[\hat{f} \left ( \xi  \right )= \int_{-\infty}^{\infty} f\left ( x  \right ) e^{-i2\pi \xi x} dx\\]
+``````
+Next, invoke LuaTeX from the terminal:
+``` sh
+texlua ⟨CLI pathname⟩ -- content.md optionfalse.tex
+texlua ⟨CLI pathname⟩ texMathDoubleBackslash=true -- content.md optiontrue.tex
+luatex document.tex
+```````
+where \meta{CLI pathname} corresponds to the location of the Lua CLI script file,
+such as `~/texmf/scripts/markdown/markdown-cli.lua` on UN\*X systems or
+`C:\Users\`\meta{Your username}`\texmf\scripts\markdown\markdown-cli.lua` on Windows
+systems. Use the command `kpsewhich -a markdown-cli.lua` to locate the Lua CLI
+script file using [Kpathsea][].
+
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> \\\(E=mc^2\\)
+> 
+> \\\[\hat{f} \left ( \xi  \right )= \int_{-\infty}^{\infty} f\left ( x  \right ) e^{-i2\pi \xi x} dx\\]
+>
+> \\(E=mc^2\\)
+> 
+> \\[\hat{f} \left ( \xi  \right )= \int_{-\infty}^{\infty} f\left ( x  \right ) e^{-i2\pi \xi x} dx\\]
+
+##### Plain \TeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\input markdown
+
+\def\markdownOptionTexMathDoubleBackslash{true}
+\markdownBegin
+\\(E=mc^2\\)
+
+\\[\hat{f} \left ( \xi  \right )= \int_{-\infty}^{\infty} f\left ( x  \right ) e^{-i2\pi \xi x} dx\\]
+\markdownEnd
+
+\bye
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+luatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> \\(E=mc^2\\)
+> 
+> \\[\hat{f} \left ( \xi  \right )= \int_{-\infty}^{\infty} f\left ( x  \right ) e^{-i2\pi \xi x} dx\\]
+
+##### \LaTeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\documentclass{article}
+\usepackage[texMathDoubleBackslash]{markdown}
+\begin{document}
+
+\begin{markdown}
+\\(E=mc^2\\)
+
+\\[\hat{f} \left ( \xi  \right )= \int_{-\infty}^{\infty} f\left ( x  \right ) e^{-i2\pi \xi x} dx\\]
+\end{markdown}
+
+\end{document}
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+lualatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> \\(E=mc^2\\)
+> 
+> \\[\hat{f} \left ( \xi  \right )= \int_{-\infty}^{\infty} f\left ( x  \right ) e^{-i2\pi \xi x} dx\\]
+
+##### \Hologo{ConTeXt} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\usemodule[t][markdown]
+\setupmarkdown[texMathDoubleBackslash = yes]
+\starttext
+
+\startmarkdown
+\\(E=mc^2\\)
+
+\\[\hat{f} \left ( \xi  \right )= \int_{-\infty}^{\infty} f\left ( x  \right ) e^{-i2\pi \xi x} dx\\]
+\stopmarkdown
+
+\stoptext
+````````
+Next, invoke LuaTeX from the terminal:
+``` sh
+context document.tex
+`````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> \\(E=mc^2\\)
+> 
+> \\[\hat{f} \left ( \xi  \right )= \int_{-\infty}^{\infty} f\left ( x  \right ) e^{-i2\pi \xi x} dx\\]
+
+%</manual-options>
+%<*tex>
+% \fi
+%  \begin{macrocode}
+\@@_add_lua_option:nnn
+  { texMathDoubleBackslash }
+  { boolean }
+  { false }
+%    \end{macrocode}
+% \iffalse
+%</tex>
+%<*lua,lua-cli>
+% \fi
+%  \begin{macrocode}
+defaultOptions.texMathDoubleBackslash = false
+%    \end{macrocode}
+% \par
+% \iffalse
+%</lua,lua-cli>
+%<*manual-options>
+
+#### Option `texMathSingleBackslash`
+
+`texMathSingleBackslash` (default value: `false`)
+
+% \fi
+% \begin{markdown}
+%
+% \Optitem[false]{texMathSingleBackslash}{\opt{true}, \opt{false}}
+%
+:    true
+
+     :  Enable the Pandoc `tex_math_single_backslash` syntax extension:
+
+        ``` md
+        inline math: \(E=mc^2\)
+
+        display math: \[E=mc^2\]
+        ```
+
+:    false
+
+     :  Disable the Pandoc `tex_math_single_backslash` syntax extension.
+
+% \end{markdown}
+% \iffalse
+
+##### Lua Module Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\input markdown
+\input lmfonts
+\directlua{
+  local markdown = require("markdown")
+  local newline = [[^^J^^J]]
+  local convert = markdown.new({texMathSingleBackslash = true})
+  local input =
+    [[\(E=mc^2\)]] .. newline .. newline ..
+    [[\[\hat{f} \left ( \xi  \right )= \int_{-\infty}^{\infty} f\left ( x  \right ) e^{-i2\pi \xi x} dx\]]]
+  tex.sprint(convert(input)) }
+\bye
+```````
+Then, invoke LuaTeX from the terminal:
+``` sh
+luatex document.tex
+```````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> \(E=mc^2\)
+>
+> \[\hat{f} \left ( \xi  \right )= \int_{-\infty}^{\infty} f\left ( x  \right ) e^{-i2\pi \xi x} dx\]
+
+##### Lua CLI Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\input markdown
+\input lmfonts
+\input optionfalse
+\par
+\input optiontrue
+\bye
+```````
+Using a text editor, create a text document named `content.md` with the
+following content:
+``` md
+\(E=mc^2\)
+
+\[\hat{f} \left ( \xi  \right )= \int_{-\infty}^{\infty} f\left ( x  \right ) e^{-i2\pi \xi x} dx\]
+``````
+Next, invoke LuaTeX from the terminal:
+``` sh
+texlua ⟨CLI pathname⟩ -- content.md optionfalse.tex
+texlua ⟨CLI pathname⟩ texMathSingleBackslash=true -- content.md optiontrue.tex
+luatex document.tex
+```````
+where \meta{CLI pathname} corresponds to the location of the Lua CLI script file,
+such as `~/texmf/scripts/markdown/markdown-cli.lua` on UN\*X systems or
+`C:\Users\`\meta{Your username}`\texmf\scripts\markdown\markdown-cli.lua` on Windows
+systems. Use the command `kpsewhich -a markdown-cli.lua` to locate the Lua CLI
+script file using [Kpathsea][].
+
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> (E=mc^2)
+> 
+> [\hat{f} \left ( \xi  \right )= \int_{-\infty}^{\infty} f\left ( x  \right ) e^{-i2\pi \xi x} dx]
+>
+> \(E=mc^2\)
+> 
+> \[\hat{f} \left ( \xi  \right )= \int_{-\infty}^{\infty} f\left ( x  \right ) e^{-i2\pi \xi x} dx\]
+
+##### Plain \TeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\input markdown
+
+\def\markdownOptionTexMathSingleBackslash{true}
+\markdownBegin
+\(E=mc^2\)
+
+\[\hat{f} \left ( \xi  \right )= \int_{-\infty}^{\infty} f\left ( x  \right ) e^{-i2\pi \xi x} dx\]
+\markdownEnd
+
+\bye
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+luatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> \(E=mc^2\)
+> 
+> \[\hat{f} \left ( \xi  \right )= \int_{-\infty}^{\infty} f\left ( x  \right ) e^{-i2\pi \xi x} dx\]
+
+##### \LaTeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\documentclass{article}
+\usepackage[texMathSingleBackslash]{markdown}
+\begin{document}
+
+\begin{markdown}
+\(E=mc^2\)
+
+\[\hat{f} \left ( \xi  \right )= \int_{-\infty}^{\infty} f\left ( x  \right ) e^{-i2\pi \xi x} dx\]
+\end{markdown}
+
+\end{document}
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+lualatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> \(E=mc^2\)
+> 
+> \[\hat{f} \left ( \xi  \right )= \int_{-\infty}^{\infty} f\left ( x  \right ) e^{-i2\pi \xi x} dx\]
+
+##### \Hologo{ConTeXt} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\usemodule[t][markdown]
+\setupmarkdown[texMathSingleBackslash = yes]
+\starttext
+
+\startmarkdown
+\(E=mc^2\)
+
+\[\hat{f} \left ( \xi  \right )= \int_{-\infty}^{\infty} f\left ( x  \right ) e^{-i2\pi \xi x} dx\]
+\stopmarkdown
+
+\stoptext
+````````
+Next, invoke LuaTeX from the terminal:
+``` sh
+context document.tex
+`````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> \(E=mc^2\)
+> 
+> \[\hat{f} \left ( \xi  \right )= \int_{-\infty}^{\infty} f\left ( x  \right ) e^{-i2\pi \xi x} dx\]
+
+%</manual-options>
+%<*tex>
+% \fi
+%  \begin{macrocode}
+\@@_add_lua_option:nnn
+  { texMathSingleBackslash }
+  { boolean }
+  { false }
+%    \end{macrocode}
+% \iffalse
+%</tex>
+%<*lua,lua-cli>
+% \fi
+%  \begin{macrocode}
+defaultOptions.texMathSingleBackslash = false
+%    \end{macrocode}
+% \par
+% \iffalse
+%</lua,lua-cli>
+%<*manual-options>
+
 #### Option `tightLists`
 
 `tightLists` (default value: `true`)
@@ -9239,27 +9833,27 @@ defaultOptions.texMathDollars = false
 %
 :    true
 
-     :   Unordered and ordered lists whose items do not consist of multiple
-         paragraphs will be considered *tight*. Tight lists will produce tight
-         renderers that may produce different output than lists that are not
-         tight:
+     :  Unordered and ordered lists whose items do not consist of multiple
+        paragraphs will be considered *tight*. Tight lists will produce tight
+        renderers that may produce different output than lists that are not
+        tight:
 
-         ``` md
-         - This is
-         - a tight
-         - unordered list.
+        ``` md
+        - This is
+        - a tight
+        - unordered list.
 
-         - This is
+        - This is
 
-           not a tight
+          not a tight
 
-         - unordered list.
-         ```
+        - unordered list.
+        ```
 
 :    false
 
-     :   Unordered and ordered lists whose items consist of multiple paragraphs
-         will be treated the same way as lists that consist of multiple paragraphs.
+     :  Unordered and ordered lists whose items consist of multiple paragraphs
+        will be treated the same way as lists that consist of multiple paragraphs.
 
 % \end{markdown}
 % \iffalse
@@ -11566,6 +12160,87 @@ following text:
 %
 % \begin{markdown}
 
+#### Code Span Attribute Context Renderers
+The following macros are only produced, when the \Opt{inlineCodeAttributes}
+option is enabled.
+
+The \mdef{markdownRendererCodeSpanAttributeContextBegin} and
+\mdef{markdownRendererCodeSpanAttributeContextEnd} macros represent the beginning
+and the end of an inline code span in which the attributes of the inline code
+span apply. The macros receive no arguments.
+
+% \end{markdown}
+%
+% \iffalse
+
+##### \LaTeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\documentclass{article}
+\usepackage[inlineCodeAttributes]{markdown}
+\markdownSetup{
+  renderers = {
+    codeSpanAttributeContextBegin = {(},
+    codeSpan = {#1},
+    codeSpanAttributeContextEnd = {)},
+  },
+}
+\begin{document}
+\begin{markdown}
+
+foo `bar`{key=value} baz
+
+\end{markdown}
+\end{document}
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+lualatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> foo (bar) baz
+
+%</manual-tokens>
+%<*tex>
+% \fi
+%
+%  \begin{macrocode}
+\def\markdownRendererCodeSpanAttributeContextBegin{%
+  \markdownRendererCodeSpanAttributeContextBeginPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { codeSpanAttributeContextBegin }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { codeSpanAttributeContextBegin }
+  { 0 }
+\ExplSyntaxOff
+\def\markdownRendererCodeSpanAttributeContextEnd{%
+  \markdownRendererCodeSpanAttributeContextEndPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { codeSpanAttributeContextEnd }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { codeSpanAttributeContextEnd }
+  { 0 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
+% \begin{markdown}
+
 #### Content Block Renderers {#texcontentblockrenderers}
 
 The \mdef{markdownRendererContentBlock} macro represents an iA\,Writer content
@@ -13621,6 +14296,87 @@ that the \TeX{} engine has shell access.
 %
 % \begin{markdown}
 
+#### Image Attribute Context Renderers
+The following macros are only produced, when the \Opt{linkAttributes} option
+is enabled.
+
+The \mdef{markdownRendererImageAttributeContextBegin} and
+\mdef{markdownRendererImageAttributeContextEnd} macros represent the beginning
+and the end of an image in which the attributes of the image apply. The macros
+receive no arguments.
+
+% \end{markdown}
+%
+% \iffalse
+
+##### \LaTeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\documentclass{article}
+\usepackage[linkAttributes]{markdown}
+\markdownSetup{
+  renderers = {
+    imageAttributeContextBegin = {(},
+    image = {#1},
+    imageAttributeContextEnd = {)},
+  },
+}
+\begin{document}
+\begin{markdown}
+
+foo ![bar](#bar){key=value} baz
+
+\end{markdown}
+\end{document}
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+lualatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> foo (bar) baz
+
+%</manual-tokens>
+%<*tex>
+% \fi
+%
+%  \begin{macrocode}
+\def\markdownRendererImageAttributeContextBegin{%
+  \markdownRendererImageAttributeContextBeginPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { imageAttributeContextBegin }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { imageAttributeContextBegin }
+  { 0 }
+\ExplSyntaxOff
+\def\markdownRendererImageAttributeContextEnd{%
+  \markdownRendererImageAttributeContextEndPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { imageAttributeContextEnd }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { imageAttributeContextEnd }
+  { 0 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
+% \begin{markdown}
+
 #### Interblock Separator Renderer
 The \mdef{markdownRendererInterblockSeparator} macro represents a separator
 between two markdown block elements. The macro receives no arguments.
@@ -13759,7 +14515,7 @@ following text:
 The following macros are only produced, when the \Opt{lineBlocks} option
 is enabled.
 
-The \mdef{markdownRendererLineBlockBegin} and \mdef{markdownRendererLineBlockEnd} macros 
+The \mdef{markdownRendererLineBlockBegin} and \mdef{markdownRendererLineBlockEnd} macros
 represent the beginning and the end of a line block. The macros receive no arguments.
 
 % \end{markdown}
@@ -14149,6 +14905,87 @@ following text:
   \g_@@_renderer_arities_prop
   { link }
   { 4 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
+% \begin{markdown}
+
+#### Link Attribute Context Renderers
+The following macros are only produced, when the \Opt{linkAttributes} option
+is enabled.
+
+The \mdef{markdownRendererLinkAttributeContextBegin} and
+\mdef{markdownRendererLinkAttributeContextEnd} macros represent the beginning
+and the end of a hyperlink in which the attributes of the hyperlink apply.
+The macros receive no arguments.
+
+% \end{markdown}
+%
+% \iffalse
+
+##### \LaTeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\documentclass{article}
+\usepackage[linkAttributes]{markdown}
+\markdownSetup{
+  renderers = {
+    linkAttributeContextBegin = {(},
+    link = {#1},
+    linkAttributeContextEnd = {)},
+  },
+}
+\begin{document}
+\begin{markdown}
+
+foo [bar](#bar){key=value} baz
+
+\end{markdown}
+\end{document}
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+lualatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> foo (bar) baz
+
+%</manual-tokens>
+%<*tex>
+% \fi
+%
+%  \begin{macrocode}
+\def\markdownRendererLinkAttributeContextBegin{%
+  \markdownRendererLinkAttributeContextBeginPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { linkAttributeContextBegin }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { linkAttributeContextBegin }
+  { 0 }
+\ExplSyntaxOff
+\def\markdownRendererLinkAttributeContextEnd{%
+  \markdownRendererLinkAttributeContextEndPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { linkAttributeContextEnd }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { linkAttributeContextEnd }
+  { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
 % \par
@@ -16280,11 +17117,11 @@ following text:
 % \begin{markdown}
 
 #### Tex Math Renderers
-The \mdef{markdownRendererInlineMath} and \mdef{markdownRendererDisplayMath} macros 
-represent inline and display \TeX{} math. 
+The \mdef{markdownRendererInlineMath} and \mdef{markdownRendererDisplayMath} macros
+represent inline and display \TeX{} math.
 Both macros receive a single argument that corresponds to the tex math content.
-These macros will only be produced, when the \Opt{texMathDollars}
-option is enabled.
+These macros will only be produced, when the \Opt{texMathDollars},
+\Opt{texMathSingleBackslash}, or \Opt{texMathDoubleBackslash} option are enabled.
 
 % \end{markdown}
 %
@@ -17556,7 +18393,7 @@ following text:
 %    \end{macrocode}
 % \par
 % \begin{markdown}
-% 
+%
 %### Logging Facilities
 % The \mdef{markdownInfo}, \mdef{markdownWarning}, and \mdef{markdownError}
 % macros perform logging for the Markdown package. Their first argument
@@ -21944,12 +22781,25 @@ function M.writer.new(options)
 % \begin{markdown}
 %
 % Define \luamdef{writer->code} as a function that will transform an input
-% inline code span `s` to the output format.
+% inline code span `s` with optional attributes `attributes` to the output
+% format.
 %
 % \end{markdown}
 %  \begin{macrocode}
-  function self.code(s)
-    return {"\\markdownRendererCodeSpan{",self.escape(s),"}"}
+  function self.code(s, attributes)
+    local buf = {}
+    if attributes ~= nil then
+      table.insert(buf,
+                   "\\markdownRendererCodeSpanAttributeContextBegin\n")
+      table.insert(buf, self.attributes(attributes))
+    end
+    table.insert(buf,
+                 {"\\markdownRendererCodeSpan{", self.escape(s), "}"})
+    if attributes ~= nil then
+      table.insert(buf,
+                   "\n\\markdownRendererCodeSpanAttributeContextEnd ")
+    end
+    return buf
   end
 %    \end{macrocode}
 % \par
@@ -21957,15 +22807,27 @@ function M.writer.new(options)
 %
 % Define \luamdef{writer->link} as a function that will transform an input
 % hyperlink to the output format, where `lab` corresponds to the label,
-% `src` to \acro{uri}, and `tit` to the title of the link.
+% `src` to \acro{uri}, `tit` to the title of the link, and `attributes` to
+% optional attributes.
 %
 % \end{markdown}
 %  \begin{macrocode}
-  function self.link(lab,src,tit)
-    return {"\\markdownRendererLink{",lab,"}",
-                          "{",self.escape(src),"}",
-                          "{",self.uri(src),"}",
-                          "{",self.string(tit or ""),"}"}
+  function self.link(lab, src, tit, attributes)
+    local buf = {}
+    if attributes ~= nil then
+      table.insert(buf,
+                   "\\markdownRendererLinkAttributeContextBegin\n")
+      table.insert(buf, self.attributes(attributes))
+    end
+    table.insert(buf, {"\\markdownRendererLink{",lab,"}",
+                       "{",self.escape(src),"}",
+                       "{",self.uri(src),"}",
+                       "{",self.string(tit or ""),"}"})
+    if attributes ~= nil then
+      table.insert(buf,
+                   "\n\\markdownRendererLinkAttributeContextEnd ")
+    end
+    return buf
   end
 %    \end{macrocode}
 % \par
@@ -21973,15 +22835,27 @@ function M.writer.new(options)
 %
 % Define \luamdef{writer->image} as a function that will transform an input
 % image to the output format, where `lab` corresponds to the label, `src`
-% to the \acro{url}, and `tit` to the title of the image.
+% to the \acro{url}, `tit` to the title of the image, and `attributes` to
+% optional attributes.
 %
 % \end{markdown}
 %  \begin{macrocode}
-  function self.image(lab,src,tit)
-    return {"\\markdownRendererImage{",lab,"}",
-                           "{",self.string(src),"}",
-                           "{",self.uri(src),"}",
-                           "{",self.string(tit or ""),"}"}
+  function self.image(lab, src, tit, attributes)
+    local buf = {}
+    if attributes ~= nil then
+      table.insert(buf,
+                   "\\markdownRendererImageAttributeContextBegin\n")
+      table.insert(buf, self.attributes(attributes))
+    end
+    table.insert(buf, {"\\markdownRendererImage{",lab,"}",
+                       "{",self.string(src),"}",
+                       "{",self.uri(src),"}",
+                       "{",self.string(tit or ""),"}"})
+    if attributes ~= nil then
+      table.insert(buf,
+                   "\n\\markdownRendererImageAttributeContextEnd ")
+    end
+    return buf
   end
 %    \end{macrocode}
 % \par
@@ -22231,8 +23105,14 @@ function M.writer.new(options)
     local buf = {}
 
     table.sort(attr)
+    local seen = {}
     local key, value
     for i = 1, #attr do
+      if seen[attr[i]] ~= nil then
+        goto continue  -- prevent duplicate attributes
+      else
+        seen[attr[i]] = true
+      end
       if attr[i]:sub(1, 1) == "#" then
         table.insert(buf, {"\\markdownRendererAttributeIdentifier{",
                            attr[i]:sub(2), "}"})
@@ -22244,6 +23124,7 @@ function M.writer.new(options)
         table.insert(buf, {"\\markdownRendererAttributeKeyValue{",
                            key, "}{", value, "}"})
       end
+      ::continue::
     end
 
     return buf
@@ -22865,6 +23746,15 @@ parsers.title       = parsers.title_d + parsers.title_s + parsers.title_p
 parsers.optionaltitle
                     = parsers.spnl * parsers.title * parsers.spacechar^0
                     + Cc("")
+
+parsers.indirect_link
+                    = parsers.tag
+                    * ( C(parsers.spnl) * parsers.tag
+                      + Cc(nil) * Cc(nil)  -- always produce exactly two captures
+                      )
+
+parsers.indirect_image
+                    = parsers.exclamation * parsers.indirect_link
 %    \end{macrocode}
 % \par
 % \begin{markdown}
@@ -22989,14 +23879,14 @@ parsers.tagentity = parsers.ampersand * C(parsers.alphanumeric^1)
 % \par
 % \begin{markdown}
 %
-%#### Helpers for References
+%#### Helpers for Link Reference Definitions
 %
 % \end{markdown}
 %  \begin{macrocode}
 -- parse a reference definition:  [foo]: /bar "title"
 parsers.define_reference_parser = parsers.leader * parsers.tag * parsers.colon
                                 * parsers.spacechar^0 * parsers.url
-                                * parsers.optionaltitle * parsers.blankline^1
+                                * parsers.optionaltitle
 %    \end{macrocode}
 % \par
 % \begin{markdown}
@@ -23014,7 +23904,26 @@ parsers.between = function(p, starter, ender)
   return (starter * #parsers.nonspacechar * Ct(p * (p - ender2)^0) * ender2)
 end
 
-parsers.urlchar      = parsers.anyescaped - parsers.newline - parsers.more
+parsers.urlchar       = parsers.anyescaped
+                      - parsers.newline
+                      - parsers.more
+
+parsers.auto_link_url = parsers.less
+                      * C( parsers.alphanumeric^1 * P("://")
+                         * parsers.urlchar^1)
+                      * parsers.more
+
+parsers.auto_link_email
+                      = parsers.less
+                      * C((parsers.alphanumeric + S("-._+"))^1
+                      * P("@") * parsers.urlchar^1)
+                      * parsers.more
+
+parsers.auto_link_relative_reference
+                      = parsers.less
+                      * C(parsers.urlchar^1)
+                      * parsers.more
+
 %    \end{macrocode}
 % \par
 % \begin{markdown}
@@ -23317,52 +24226,102 @@ function M.reader.new(writer, options)
 % \par
 % \begin{markdown}
 %
-%#### Helpers for Links and References (local)
+%#### Helpers for Links and Link Reference Definitions (local)
 %
 % \end{markdown}
 %  \begin{macrocode}
   -- List of references defined in the document
   local references
 
-  -- add a reference to the list
-  local function register_link(tag,url,title)
-      references[self.normalize_tag(tag)] = { url = url, title = title }
-      return ""
+%    \end{macrocode}
+% \par
+% \begin{markdown}
+%
+% The \luamdef{reader->register_link} method registers
+% a link reference, where `tag` is the link label, `url`
+% is the link destination, `title` is the optional link
+% title, and `attributes` are the optional attributes.
+%
+% \end{markdown}
+%  \begin{macrocode}
+  function self.register_link(tag, url, title,
+                              attributes)
+    tag = self.normalize_tag(tag)
+    references[tag] = {
+      url = url,
+      title = title,
+      attributes = attributes,
+    }
+    return ""
   end
 
-  -- lookup link reference and return either
-  -- the link or nil and fallback text.
-  local function lookup_reference(label,sps,tag)
-      local tagpart
-      if not tag then
-          tag = label
-          tagpart = ""
-      elseif tag == "" then
-          tag = label
-          tagpart = "[]"
-      else
-          tagpart = {"[",
-            self.parser_functions.parse_inlines(tag),
-            "]"}
+%    \end{macrocode}
+% \par
+% \begin{markdown}
+%
+% The \luamdef{reader->lookup_reference} method looks up a
+% reference with link label `tag`. When the reference exists
+% the method returns a link. The attributes of a link are
+% produced by merging the attributes of the link reference
+% and the optional `attributes`. Otherwise, the method returns a
+% two-tuple of `nil` and fallback text constructed from the
+% link text `label` and the optional spaces `sps` between the
+% link text and the link label.
+%
+% \end{markdown}
+%  \begin{macrocode}
+  function self.lookup_reference(label, sps, tag,
+                                 attributes)
+    local tagpart
+    if not tag then
+      tag = label
+      tagpart = ""
+    elseif tag == "" then
+      tag = label
+      tagpart = "[]"
+    else
+      tagpart = {
+        "[",
+        self.parser_functions.parse_inlines(tag),
+        "]"
+      }
+    end
+    if sps then
+      tagpart = {sps, tagpart}
+    end
+    tag = self.normalize_tag(tag)
+    local r = references[tag]
+    if r then
+      local merged_attributes = {}
+      for _, attribute in ipairs(r.attributes or {}) do
+        table.insert(merged_attributes, attribute)
       end
-      if sps then
-        tagpart = {sps, tagpart}
+      for _, attribute in ipairs(attributes or {}) do
+        table.insert(merged_attributes, attribute)
       end
-      local r = references[self.normalize_tag(tag)]
-      if r then
-        return r
-      else
-        return nil, {"[",
-          self.parser_functions.parse_inlines(label),
-          "]", tagpart}
+      if #merged_attributes == 0 then
+        merged_attributes = nil
       end
+      return {
+        url = r.url,
+        title = r.title,
+        attributes = merged_attributes,
+      }
+    else
+      return nil, {
+        "[",
+        self.parser_functions.parse_inlines(label),
+        "]",
+        tagpart
+      }
+    end
   end
 
   -- lookup link reference and return a link, if the reference is found,
   -- or a bracketed label otherwise.
-  local function indirect_link(label,sps,tag)
+  local function indirect_link(label, sps, tag)
     return writer.defer_call(function()
-      local r,fallback = lookup_reference(label,sps,tag)
+      local r,fallback = self.lookup_reference(label, sps, tag)
       if r then
         return writer.link(
           self.parser_functions.parse_inlines_no_link(label),
@@ -23375,9 +24334,9 @@ function M.reader.new(writer, options)
 
   -- lookup image reference and return an image, if the reference is found,
   -- or a bracketed label otherwise.
-  local function indirect_image(label,sps,tag)
+  local function indirect_image(label, sps, tag)
     return writer.defer_call(function()
-      local r,fallback = lookup_reference(label,sps,tag)
+      local r,fallback = self.lookup_reference(label, sps, tag)
       if r then
         return writer.image(writer.string(label), r.url, r.title)
       else
@@ -23385,6 +24344,19 @@ function M.reader.new(writer, options)
       end
     end)
   end
+
+  parsers.direct_link_tail = parsers.spnl
+                           * parsers.lparent
+                           * (parsers.url + Cc(""))  -- link can be empty [foo]()
+                           * parsers.optionaltitle
+                           * parsers.rparent
+
+  parsers.direct_link = (parsers.tag / self.parser_functions.parse_inlines_no_link)
+                      * parsers.direct_link_tail
+
+  parsers.direct_image = parsers.exclamation
+                       * (parsers.tag / self.parser_functions.parse_inlines)
+                       * parsers.direct_link_tail
 %    \end{macrocode}
 % \par
 % \begin{markdown}
@@ -23485,55 +24457,63 @@ function M.reader.new(writer, options)
                      ) / writer.emphasis
   end
 
-  parsers.AutoLinkUrl    = parsers.less
-                         * C(parsers.alphanumeric^1 * P("://") * parsers.urlchar^1)
-                         * parsers.more
-                         / function(url)
-                             return writer.link(writer.escape(url), url)
-                           end
+%    \end{macrocode}
+% \par
+% \begin{markdown}
+%
+% The \luamdef{reader->auto_link_url} method produces an
+% autolink to a URL or a relative reference in the output
+% format, where `url` is the link destination and
+% `attributes` are the optional attributes.
+%
+% \end{markdown}
+%  \begin{macrocode}
+function self.auto_link_url(url, attributes)
+  return writer.link(writer.escape(url),
+                     url, nil, attributes)
+end
 
-  parsers.AutoLinkEmail = parsers.less
-                        * C((parsers.alphanumeric + S("-._+"))^1
-                        * P("@") * parsers.urlchar^1)
-                        * parsers.more
-                        / function(email)
-                            return writer.link(writer.escape(email),
-                                               "mailto:"..email)
-                          end
+%    \end{macrocode}
+% \par
+% \begin{markdown}
+%
+% The \luamdef{reader->auto_link_email} method produces an
+% autolink to an e-mail in the output format, where `email` is the email
+% address destination and `attributes` are the optional attributes.
+%
+% \end{markdown}
+%  \begin{macrocode}
+function self.auto_link_email(email, attributes)
+  return writer.link(writer.escape(email),
+                     "mailto:"..email,
+                     nil, attributes)
+end
+
+  parsers.AutoLinkUrl = parsers.auto_link_url
+                      / self.auto_link_url
+
+  parsers.AutoLinkEmail
+                      = parsers.auto_link_email
+                      / self.auto_link_email
 
   parsers.AutoLinkRelativeReference
-                         = parsers.less
-                         * C(parsers.urlchar^1)
-                         * parsers.more
-                         / function(url)
-                             return writer.link(writer.escape(url), url)
-                           end
+                      = parsers.auto_link_relative_reference
+                      / self.auto_link_url
 
-  parsers.DirectLink    = (parsers.tag / self.parser_functions.parse_inlines_no_link)
-                        * parsers.spnl
-                        * parsers.lparent
-                        * (parsers.url + Cc(""))  -- link can be empty [foo]()
-                        * parsers.optionaltitle
-                        * parsers.rparent
+  parsers.DirectLink    = parsers.direct_link
                         / writer.link
 
-  parsers.IndirectLink  = parsers.tag * (C(parsers.spnl) * parsers.tag)^-1
+  parsers.IndirectLink  = parsers.indirect_link
                         / indirect_link
 
   -- parse a link or image (direct or indirect)
   parsers.Link          = parsers.DirectLink + parsers.IndirectLink
 
-  parsers.DirectImage   = parsers.exclamation
-                        * (parsers.tag / self.parser_functions.parse_inlines)
-                        * parsers.spnl
-                        * parsers.lparent
-                        * (parsers.url + Cc(""))  -- link can be empty [foo]()
-                        * parsers.optionaltitle
-                        * parsers.rparent
+  parsers.DirectImage   = parsers.direct_image
                         / writer.image
 
-  parsers.IndirectImage = parsers.exclamation * parsers.tag
-                        * (C(parsers.spnl) * parsers.tag)^-1 / indirect_image
+  parsers.IndirectImage = parsers.indirect_image
+                        / indirect_image
 
   parsers.Image         = parsers.DirectImage + parsers.IndirectImage
 
@@ -23584,7 +24564,9 @@ function M.reader.new(writer, options)
                           + parsers.lineof(parsers.underscore)
                           ) / writer.thematic_break
 
-  parsers.Reference    = parsers.define_reference_parser / register_link
+  parsers.Reference    = parsers.define_reference_parser
+                       * parsers.blankline^1
+                       / self.register_link
 
   parsers.Paragraph    = parsers.nonindentspace * Ct(parsers.Inline^1)
                        * ( parsers.newline
@@ -23680,7 +24662,7 @@ function M.reader.new(writer, options)
 % \end{markdown}
 %  \begin{macrocode}
   parsers.Blank        = parsers.blankline / ""
-                       + parsers.Reference
+                       + V("Reference")
                        + (parsers.tightblocksep / "\n")
 %    \end{macrocode}
 % \par
@@ -23818,6 +24800,7 @@ function M.reader.new(writer, options)
         ExpectedJekyllData    = parsers.fail,
 
         Blank                 = parsers.Blank,
+        Reference             = parsers.Reference,
 
         Blockquote            = parsers.Blockquote,
         Verbatim              = parsers.Verbatim,
@@ -23881,7 +24864,33 @@ function M.reader.new(writer, options)
         previous_pattern = nil
         extension_name = current_extension_name
       end
-      local pattern = get_pattern(previous_pattern)
+      local pattern
+%    \end{macrocode}
+% \par
+% \begin{markdown}
+%
+% Instead of a function, a \acro{peg} pattern `pattern` may also be
+% supplied with roughly the same effect as supplying the following
+% function, which will define \luamref{walkable_syntax}`[`left-hand
+% side terminal symbol`]` unless it has been previously defined.
+%
+% ``` lua
+% function(previous_pattern)
+%   assert(previous_pattern == nil)
+%   return pattern
+% end
+% ```
+%
+% \end{markdown}
+%  \begin{macrocode}
+      if type(get_pattern) == "function" then
+        pattern = get_pattern(previous_pattern)
+      else
+        assert(previous_pattern == nil,
+               [[Rule ]] .. rule_name ..
+               [[ has already been updated by ]] .. extension_name)
+        pattern = get_pattern
+      end
       local accountable_pattern = { pattern, extension_name, rule_name }
       walkable_syntax[rule_name] = { accountable_pattern }
     end
@@ -24891,7 +25900,7 @@ M.extensions.fancy_lists = function()
                       * Cc(false) * parsers.skipblanklines
                       ) * Cb("listtype") / fancylist
 
-      self.update_rule("OrderedList", function() return FancyList end)
+      self.update_rule("OrderedList", FancyList)
     end
   }
 end
@@ -25310,7 +26319,34 @@ M.extensions.header_attributes = function()
                           / writer.heading
 
       local Heading = AtxHeading + SetextHeading
-      self.update_rule("Heading", function() return Heading end)
+      self.update_rule("Heading", Heading)
+    end
+  }
+end
+%    \end{macrocode}
+% \begin{markdown}
+%
+%#### Inline Code Attributes
+%
+% The \luamdef{extensions.inline_code_attributes} function implements the
+% Pandoc inline code attributes syntax extension.
+%
+% \end{markdown}
+%  \begin{macrocode}
+M.extensions.inline_code_attributes = function()
+  return {
+    name = "built-in inline_code_attributes syntax extension",
+    extend_writer = function()
+    end, extend_reader = function(self)
+      local writer = self.writer
+
+      local CodeWithAttributes = parsers.inticks
+                               * Ct(parsers.attributes)
+                               / writer.code
+
+      self.insert_pattern("Inline before Code",
+                          CodeWithAttributes,
+                          "CodeWithAttributes")
     end
   }
 end
@@ -25369,6 +26405,182 @@ M.extensions.line_blocks = function()
 
       self.insert_pattern("Block after Blockquote",
                            LineBlock, "LineBlock")
+    end
+  }
+end
+%    \end{macrocode}
+% \begin{markdown}
+%
+%#### Link Attributes
+%
+% The \luamdef{extensions.link_attributes} function implements the Pandoc
+% link attributes syntax extension.
+%
+% \end{markdown}
+%  \begin{macrocode}
+M.extensions.link_attributes = function()
+  return {
+    name = "built-in link_attributes syntax extension",
+    extend_writer = function()
+    end, extend_reader = function(self)
+      local parsers = self.parsers
+      local writer = self.writer
+      local options = self.options
+
+%    \end{macrocode}
+% \begin{markdown}
+%
+% The following patterns define link reference definitions with attributes.
+%
+% \end{markdown}
+%  \begin{macrocode}
+
+      local define_reference_parser = parsers.define_reference_parser
+                                    * ( parsers.spnl
+                                      * Ct(parsers.attributes))^-1
+
+      local ReferenceWithAttributes = define_reference_parser
+                                    * parsers.blankline^1
+                                    / self.register_link
+
+      self.update_rule("Reference", ReferenceWithAttributes)
+
+%    \end{macrocode}
+% \begin{markdown}
+%
+% The following patterns define direct and indirect links with attributes.
+%
+% \end{markdown}
+%  \begin{macrocode}
+
+      local function indirect_link(label, sps, tag,
+                                   attribute_text,
+                                   attributes)
+        return writer.defer_call(function()
+          local r, fallback = self.lookup_reference(label, sps, tag,
+                                                    attributes)
+          if r then
+            return writer.link(
+              self.parser_functions.parse_inlines_no_link(label),
+              r.url, r.title, r.attributes)
+          else
+            local buf = {fallback}
+            if attributes then
+              table.insert(buf, writer.string(attribute_text))
+            end
+            return buf
+          end
+        end)
+      end
+
+      local DirectLinkWithAttributes = parsers.direct_link
+                                     * (Ct(parsers.attributes))^-1
+                                     / writer.link
+
+      local IndirectLinkWithAttributes = parsers.indirect_link
+                                       * (C(Ct(parsers.attributes)))^-1
+                                       / indirect_link
+
+      local LinkWithAttributes = DirectLinkWithAttributes
+                               + IndirectLinkWithAttributes
+
+%    \end{macrocode}
+% \begin{markdown}
+%
+% Here, we directly update the `Link` grammar rule to keep the
+% method \luamref{reader->parser_functions.parse_inlines_no_link}
+% aware of `LinkWithAttributes` and prevent nested links.
+%
+% If we used \luamref{reader->insert_pattern} instead of
+% \luamref{reader->update_rule}, this correspondence would have
+% been lost and link text would be able to contain nested links.
+%
+% \end{markdown}
+%  \begin{macrocode}
+      self.update_rule("Link", LinkWithAttributes)
+
+%    \end{macrocode}
+% \begin{markdown}
+%
+% The following patterns define direct and indirect images with attributes.
+%
+% \end{markdown}
+%  \begin{macrocode}
+
+      local function indirect_image(label, sps, tag,
+                                    attribute_text,
+                                    attributes)
+        return writer.defer_call(function()
+          local r, fallback = self.lookup_reference(label, sps, tag,
+                                                    attributes)
+          if r then
+            return writer.image(writer.string(label),
+                                r.url, r.title, r.attributes)
+          else
+            local buf = {"!", fallback}
+            if attributes then
+              table.insert(buf, writer.string(attribute_text))
+            end
+            return buf
+          end
+        end)
+      end
+
+      local DirectImageWithAttributes = parsers.direct_image
+                                      * Ct(parsers.attributes)
+                                      / writer.image
+
+      local IndirectImageWithAttributes = parsers.indirect_image
+                                        * C(Ct(parsers.attributes))
+                                        / indirect_image
+
+      local ImageWithAttributes = DirectImageWithAttributes
+                                + IndirectImageWithAttributes
+
+      self.insert_pattern("Inline before Image",
+                          ImageWithAttributes,
+                          "ImageWithAttributes")
+
+%    \end{macrocode}
+% \begin{markdown}
+%
+% The following patterns define autolinks with attributes.
+%
+% \end{markdown}
+%  \begin{macrocode}
+
+      local AutoLinkUrlWithAttributes
+                      = parsers.auto_link_url
+                      * Ct(parsers.attributes)
+                      / self.auto_link_url
+
+      self.insert_pattern("Inline before AutoLinkUrl",
+                          AutoLinkUrlWithAttributes,
+                          "AutoLinkUrlWithAttributes")
+
+      local AutoLinkEmailWithAttributes
+                      = parsers.auto_link_email
+                      * Ct(parsers.attributes)
+                      / self.auto_link_email
+
+      self.insert_pattern("Inline before AutoLinkEmail",
+                          AutoLinkEmailWithAttributes,
+                          "AutoLinkEmailWithAttributes")
+
+      if options.relativeReferences then
+
+        local AutoLinkRelativeReferenceWithAttributes
+                        = parsers.auto_link_relative_reference
+                        * Ct(parsers.attributes)
+                        / self.auto_link_url
+
+        self.insert_pattern(
+          "Inline before AutoLinkRelativeReference",
+          AutoLinkRelativeReferenceWithAttributes,
+          "AutoLinkRelativeReferenceWithAttributes")
+
+      end
+
     end
   }
 end
@@ -25453,7 +26665,7 @@ M.extensions.notes = function(notes, inline_notes)
                     / register_note
 
         local Blank = NoteBlock + parsers.Blank
-        self.update_rule("Blank", function() return Blank end)
+        self.update_rule("Blank", Blank)
 
         self.insert_pattern("Inline after Emph",
                             NoteRef, "NoteRef")
@@ -25796,16 +27008,19 @@ end
 %    \end{macrocode}
 % \begin{markdown}
 %
-%#### Tex Math Dollars
+%#### Tex Math
 %
-% The \luamdef{extensions.tex_math_dollars} function implements the Pandoc
-% tex_math_dollars syntax extension.
+% The \luamdef{extensions.tex_math} function implements the Pandoc
+% `tex_math_dollars`, `tex_math_single_backslash` and `tex_math_double_backslash`
+% syntax extensions.
 %
 % \end{markdown}
 %  \begin{macrocode}
-M.extensions.tex_math_dollars = function()
+M.extensions.tex_math = function(tex_math_dollars,
+                                 tex_math_single_backslash,
+                                 tex_math_double_backslash)
   return {
-    name = "built-in tex_math_dollars syntax extension",
+    name = "built-in tex_math syntax extension",
     extend_writer = function(self)
 %    \end{macrocode}
 % \par
@@ -25840,35 +27055,149 @@ M.extensions.tex_math_dollars = function()
         return (starter * C(p * (p - ender)^0) * ender)
       end
 
-      local inlinemathtail  = B( parsers.any * parsers.nonspacechar
-                               + parsers.backslash * parsers.any)
-                            * parsers.dollar 
-                            * -#(parsers.digit)
+      local allowed_before_closing = B( parsers.backslash * parsers.any
+                                      + parsers.any * (parsers.nonspacechar - parsers.backslash))
+%    \end{macrocode}
+% \begin{markdown}
+%
+% The following patterns implement the Pandoc `tex_math_dollars` syntax extension.
+%
+% \end{markdown}
+%  \begin{macrocode}
+      local dollar_math_content = parsers.backslash^-1
+                                * parsers.any
+                                - parsers.blankline^2
+                                - parsers.dollar
 
-      local inlinemath = between(C( parsers.backslash^-1 
-                                  * parsers.any
-                                  - parsers.blankline^2 
-                                  - parsers.dollar),
-                                 parsers.dollar * #(parsers.nonspacechar),
-                                 inlinemathtail)
+      local inline_math_opening_dollars = parsers.dollar
+                                        * #(parsers.nonspacechar)
 
-      local displaymathdelim  = parsers.dollar 
-                              * parsers.dollar
+      local inline_math_closing_dollars = allowed_before_closing
+                                        * parsers.dollar
+                                        * -#(parsers.digit)
 
-      local displaymath = between(C( parsers.backslash^-1 
-                                   * parsers.any 
-                                   - parsers.blankline^2 
-                                   - parsers.dollar),
-                                  displaymathdelim,
-                                  displaymathdelim)
+      local inline_math_dollars = between(C( dollar_math_content),
+                                          inline_math_opening_dollars,
+                                          inline_math_closing_dollars)
 
-      local TexMathDollars = displaymath / writer.display_math
-                           + inlinemath / writer.inline_math
+      local display_math_opening_dollars  = parsers.dollar
+                                          * parsers.dollar
+
+      local display_math_closing_dollars  = parsers.dollar
+                                          * parsers.dollar
+
+      local display_math_dollars = between(C( dollar_math_content),
+                                           display_math_opening_dollars,
+                                           display_math_closing_dollars)
+%    \end{macrocode}
+% \begin{markdown}
+%
+% The following patterns implement the Pandoc `tex_math_single_backslash` and
+% `tex_math_double_backslash` syntax extensions.
+%
+% \end{markdown}
+%  \begin{macrocode}
+      local backslash_math_content  = parsers.any 
+                                    - parsers.blankline^2
+%    \end{macrocode}
+% \begin{markdown}
+%
+% The following patterns implement the Pandoc `tex_math_double_backslash` syntax extension.
+%
+% \end{markdown}
+%  \begin{macrocode}
+      local inline_math_opening_double  = parsers.backslash
+                                        * parsers.backslash
+                                        * parsers.lparent
+                                        * #(parsers.nonspacechar)
+
+      local inline_math_closing_double  = allowed_before_closing
+                                        * parsers.backslash
+                                        * parsers.backslash
+                                        * parsers.rparent
+
+      local inline_math_double  = between(C( backslash_math_content),
+                                          inline_math_opening_double,
+                                          inline_math_closing_double)
+
+      local display_math_opening_double = parsers.backslash
+                                        * parsers.backslash
+                                        * parsers.lbracket
+
+      local display_math_closing_double = allowed_before_closing
+                                        * parsers.backslash
+                                        * parsers.backslash
+                                        * parsers.rbracket
+
+      local display_math_double = between(C( backslash_math_content),
+                                          display_math_opening_double,
+                                          display_math_closing_double)
+%    \end{macrocode}
+% \begin{markdown}
+%
+% The following patterns implement the Pandoc `tex_math_single_backslash` syntax extension.
+%
+% \end{markdown}
+%  \begin{macrocode}
+      local inline_math_opening_single  = parsers.backslash
+                                        * parsers.lparent
+                                        * #(parsers.nonspacechar)
+
+      local inline_math_closing_single  = allowed_before_closing
+                                        * parsers.backslash
+                                        * parsers.rparent
+
+      local inline_math_single  = between(C( backslash_math_content),
+                                          inline_math_opening_single,
+                                          inline_math_closing_single)
+
+      local display_math_opening_single = parsers.backslash
+                                        * parsers.lbracket
+
+      local display_math_closing_single = allowed_before_closing
+                                        * parsers.backslash
+                                        * parsers.rbracket
+
+      local display_math_single = between(C( backslash_math_content),
+                                          display_math_opening_single,
+                                          display_math_closing_single)
+
+      local display_math = parsers.fail
+
+      local inline_math = parsers.fail
+
+      if tex_math_dollars then
+        display_math = display_math + display_math_dollars
+        inline_math = inline_math + inline_math_dollars
+      end
+
+      if tex_math_double_backslash then
+        display_math = display_math + display_math_double
+        inline_math = inline_math + inline_math_double
+      end
+
+      if tex_math_single_backslash then
+        display_math = display_math + display_math_single
+        inline_math = inline_math + inline_math_single
+      end
+
+      local TexMath = display_math / writer.display_math
+                    + inline_math / writer.inline_math
 
       self.insert_pattern("Inline after Emph",
-                          TexMathDollars, "TexMathDollars")
+                          TexMath, "TexMath")
 
-      self.add_special_character("$")
+      if tex_math_dollars then
+        self.add_special_character("$")
+      end
+
+      if tex_math_single_backslash or tex_math_double_backslash then
+        self.add_special_character("\\")
+        self.add_special_character("[")
+        self.add_special_character("]")
+        self.add_special_character(")")
+        self.add_special_character("(")
+      end
     end
   }
 end
@@ -26023,7 +27352,7 @@ M.extensions.jekyll_data = function(expect_jekyll_data)
       self.insert_pattern("Block before Blockquote",
                           UnexpectedJekyllData, "UnexpectedJekyllData")
       if expect_jekyll_data then
-        self.update_rule("ExpectedJekyllData", function() return ExpectedJekyllData end)
+        self.update_rule("ExpectedJekyllData", ExpectedJekyllData)
       end
     end
   }
@@ -26097,10 +27426,22 @@ function M.new(options)
     table.insert(extensions, header_attributes_extension)
   end
 
+  if options.inlineCodeAttributes then
+    local inline_code_attributes_extension =
+      M.extensions.inline_code_attributes()
+    table.insert(extensions, inline_code_attributes_extension)
+  end
+
   if options.jekyllData then
     local jekyll_data_extension = M.extensions.jekyll_data(
       options.expectJekyllData)
     table.insert(extensions, jekyll_data_extension)
+  end
+
+  if options.linkAttributes then
+    local link_attributes_extension =
+      M.extensions.link_attributes()
+    table.insert(extensions, link_attributes_extension)
   end
 
   if options.lineBlocks then
@@ -26134,9 +27475,14 @@ function M.new(options)
     table.insert(extensions, superscript_extension)
   end
 
-  if options.texMathDollars then
-    local tex_math_dollars_extension = M.extensions.tex_math_dollars()
-    table.insert(extensions, tex_math_dollars_extension)
+  if options.texMathDollars or
+     options.texMathSingleBackslash or
+     options.texMathDoubleBackslash then
+    local tex_math_extension = M.extensions.tex_math(
+      options.texMathDollars,
+      options.texMathSingleBackslash,
+      options.texMathDoubleBackslash)
+    table.insert(extensions, tex_math_extension)
   end
 
 %    \end{macrocode}
@@ -26506,7 +27852,7 @@ end
 % \par
 % \begin{markdown}
 %
-%#### Raw Attribute Renderer Prototypes
+%#### Raw Attributes
 %
 % In the raw block and inline raw span renderer prototypes, execute the content
 % with TeX when the raw attribute is `tex`, display the content as markdown when
@@ -28733,9 +30079,8 @@ end
 % \begin{markdown}
 %
 %#### Links
-% Before consuming the parameters for the hyperlink renderer, we change the
-% category code of the hash sign (`#`) to other, so that it cannot be
-% mistaken for a parameter character.
+% Here is an implementation for hypertext links and relative references.
+%
 % \end{markdown}
 %  \begin{macrocode}
 \RequirePackage{url}
@@ -29010,7 +30355,68 @@ end
 % \par
 % \begin{markdown}
 %
-%#### Raw Attribute Renderer Prototypes
+%#### Strike-Through
+% If the \Opt{strikeThrough} option is enabled, we will load the
+% \pkg{soulutf8} package and use it to implement strike-throughs.
+%
+% \end{markdown}
+%  \begin{macrocode}
+\markdownIfOption{strikeThrough}{%
+  \RequirePackage{soulutf8}%
+  \markdownSetup{
+    rendererPrototypes = {
+      strikeThrough = {%
+        \st{#1}%
+      },
+    }
+  }
+}{}
+%    \end{macrocode}
+% \par
+% \begin{markdown}
+%
+%#### Image Attributes
+%
+% If the \Opt{linkAttributes} option is enabled, we will load
+% the \pkg{graphicx} package. Furthermore, in image attribute contexts,
+% we will make attributes in the form \meta{key}`=`\meta{value} set the
+% corresponding keys of the \pkg{graphicx} package to the corresponding
+% values.
+%
+% \end{markdown}
+%  \begin{macrocode}
+\ExplSyntaxOn
+\@@_if_option:nTF
+  { linkAttributes }
+  {
+    \RequirePackage{graphicx}
+    \markdownSetup{
+      rendererPrototypes = {
+        imageAttributeContextBegin = {
+          \group_begin:
+          \markdownSetup{
+            rendererPrototypes = {
+              attributeKeyValue = {
+                \setkeys
+                  { Gin }
+                  { { ##1 } = { ##2 } }
+              },
+            },
+          }
+        },
+        imageAttributeContextEnd = {
+          \group_end:
+        },
+      },
+    }
+  }
+  { }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+% \begin{markdown}
+%
+%#### Raw Attributes
 %
 % In the raw block and inline raw span renderer prototypes, default to the
 % plain TeX renderer prototypes, translating raw attribute `latex` to `tex`.
@@ -29432,7 +30838,7 @@ end
 % \par
 % \begin{markdown}
 %
-%#### Raw Attribute Renderer Prototypes
+%#### Raw Attributes
 %
 % In the raw block and inline raw span renderer prototypes, default to the
 % plain TeX renderer prototypes, translating raw attribute `context` to `tex`.

--- a/tests/support/markdownthemewitiko_markdown_test.sty
+++ b/tests/support/markdownthemewitiko_markdown_test.sty
@@ -21,6 +21,18 @@
       \TYPE{BEGIN bracketedSpanAttributeContext}},
     bracketedSpanAttributeContextEnd = {%
       \TYPE{END bracketedSpanAttributeContext}},
+    linkAttributeContextBegin = {%
+      \TYPE{BEGIN linkAttributeContext}},
+    linkAttributeContextEnd = {%
+      \TYPE{END linkAttributeContext}},
+    imageAttributeContextBegin = {%
+      \TYPE{BEGIN imageAttributeContext}},
+    imageAttributeContextEnd = {%
+      \TYPE{END imageAttributeContext}},
+    codeSpanAttributeContextBegin = {%
+      \TYPE{BEGIN codeSpanAttributeContext}},
+    codeSpanAttributeContextEnd = {%
+      \TYPE{END codeSpanAttributeContext}},
     documentBegin = {%
       \begingroup
       \catcode"09=12%  Prevent spaces (U+0009) from folding into a single space token

--- a/tests/support/plain-setup.tex
+++ b/tests/support/plain-setup.tex
@@ -19,6 +19,18 @@
   \TYPE{BEGIN bracketedSpanAttributeContext}}%
 \def\markdownRendererBracketedSpanAttributeContextEnd{%
   \TYPE{END bracketedSpanAttributeContext}}%
+\def\markdownRendererLinkAttributeContextBegin{%
+  \TYPE{BEGIN linkAttributeContext}}%
+\def\markdownRendererLinkAttributeContextEnd{%
+  \TYPE{END linkAttributeContext}}%
+\def\markdownRendererImageAttributeContextBegin{%
+  \TYPE{BEGIN imageAttributeContext}}%
+\def\markdownRendererImageAttributeContextEnd{%
+  \TYPE{END imageAttributeContext}}%
+\def\markdownRendererCodeSpanAttributeContextBegin{%
+  \TYPE{BEGIN codeSpanAttributeContext}}%
+\def\markdownRendererCodeSpanAttributeContextEnd{%
+  \TYPE{END codeSpanAttributeContext}}%
 \def\markdownRendererDocumentBegin{%
   \begingroup
   \catcode"09=12%  Prevent spaces (U+0009) from folding into a single space token

--- a/tests/testfiles/lunamark-markdown/inline-code-attributes.test
+++ b/tests/testfiles/lunamark-markdown/inline-code-attributes.test
@@ -1,0 +1,15 @@
+\def\markdownOptionInlineCodeAttributes{true}
+<<<
+This test ensures that the Lua `inlineCodeAttributes` option correctly
+propagates through the plain TeX interface.
+
+`<$>`{.haskell}
+>>>
+documentBegin
+codeSpan: inlineCodeAttributes
+interblockSeparator
+BEGIN codeSpanAttributeContext
+attributeClassName: haskell
+codeSpan: <(dollarSign)>
+END codeSpanAttributeContext
+documentEnd

--- a/tests/testfiles/lunamark-markdown/link-attributes.test
+++ b/tests/testfiles/lunamark-markdown/link-attributes.test
@@ -1,0 +1,89 @@
+\def\markdownOptionLinkAttributes{true}
+<<<
+This test ensures that the Lua `linkAttributes` option correctly
+propagates through the plain TeX interface.
+
+An inline [link](foo.jpg){#id .class width=30 height=20px},
+a reference [link][ref]{.another-class} with attributes, and
+an <https://auto/>{.link}.
+
+An inline ![image](foo.jpg){#id .class width=30 height=20px}
+and a reference ![image][ref]{.another-class} with attributes.
+
+[ref]: foo.jpg "optional title" {#id .class key=val}
+>>>
+documentBegin
+codeSpan: linkAttributes
+interblockSeparator
+BEGIN linkAttributeContext
+attributeIdentifier: id
+attributeClassName: class
+BEGIN attributeKeyValue
+- key: height
+- value: 20px
+END attributeKeyValue
+BEGIN attributeKeyValue
+- key: width
+- value: 30
+END attributeKeyValue
+BEGIN link
+- label: link
+- URI: foo.jpg
+- title: 
+END link
+END linkAttributeContext
+BEGIN linkAttributeContext
+attributeIdentifier: id
+attributeClassName: another-class
+attributeClassName: class
+BEGIN attributeKeyValue
+- key: key
+- value: val
+END attributeKeyValue
+BEGIN link
+- label: link
+- URI: foo.jpg
+- title: optional title
+END link
+END linkAttributeContext
+BEGIN linkAttributeContext
+attributeClassName: link
+BEGIN link
+- label: https://auto/
+- URI: https://auto/
+- title: 
+END link
+END linkAttributeContext
+interblockSeparator
+BEGIN imageAttributeContext
+attributeIdentifier: id
+attributeClassName: class
+BEGIN attributeKeyValue
+- key: height
+- value: 20px
+END attributeKeyValue
+BEGIN attributeKeyValue
+- key: width
+- value: 30
+END attributeKeyValue
+BEGIN image
+- label: image
+- URI: foo.jpg
+- title: 
+END image
+END imageAttributeContext
+BEGIN imageAttributeContext
+attributeIdentifier: id
+attributeClassName: another-class
+attributeClassName: class
+BEGIN attributeKeyValue
+- key: key
+- value: val
+END attributeKeyValue
+BEGIN image
+- label: image
+- URI: foo.jpg
+- title: optional title
+END image
+END imageAttributeContext
+documentEnd

--- a/tests/testfiles/lunamark-markdown/no-inline-code-attributes.test
+++ b/tests/testfiles/lunamark-markdown/no-inline-code-attributes.test
@@ -1,0 +1,13 @@
+<<<
+This test ensures that the Lua `inlineCodeAttributes` option is
+disabled by default.
+
+`<$>`{.haskell}
+>>>
+documentBegin
+codeSpan: inlineCodeAttributes
+interblockSeparator
+codeSpan: <(dollarSign)>
+leftBrace
+rightBrace
+documentEnd

--- a/tests/testfiles/lunamark-markdown/no-link-attributes.test
+++ b/tests/testfiles/lunamark-markdown/no-link-attributes.test
@@ -1,0 +1,49 @@
+<<<
+This test ensures that the Lua `linkAttributes` option is
+disabled by default.
+
+An inline [link](foo.jpg){#id .class width=30 height=20px},
+a reference [link][ref]{.another-class} with attributes, and
+an <https://auto/>{.link}.
+
+An inline ![image](foo.jpg){#id .class width=30 height=20px}
+and a reference ![image][ref]{.another-class} with attributes.
+
+[ref]: foo.jpg "optional title" {#id .class key=val}
+>>>
+documentBegin
+codeSpan: linkAttributes
+interblockSeparator
+BEGIN link
+- label: link
+- URI: foo.jpg
+- title: 
+END link
+leftBrace
+hash
+rightBrace
+leftBrace
+rightBrace
+BEGIN link
+- label: https://auto/
+- URI: https://auto/
+- title: 
+END link
+leftBrace
+rightBrace
+interblockSeparator
+BEGIN image
+- label: image
+- URI: foo.jpg
+- title: 
+END image
+leftBrace
+hash
+rightBrace
+leftBrace
+rightBrace
+interblockSeparator
+leftBrace
+hash
+rightBrace
+documentEnd

--- a/tests/testfiles/lunamark-markdown/no-tex-math-double-backslash.test
+++ b/tests/testfiles/lunamark-markdown/no-tex-math-double-backslash.test
@@ -1,0 +1,39 @@
+<<<
+This test ensures that the Lua `texMathDoubleBackslash` option is disabled by default.
+
+\\(E=mc^2\\)
+
+\\[\hat{f} \left ( \xi  \right )= \int_{-\infty}^{\infty} f\left ( x  \right ) e^{-i2\pi \xi x} dx\\]
+>>>
+documentBegin
+codeSpan: texMathDoubleBackslash
+interblockSeparator
+backslash
+circumflex
+backslash
+interblockSeparator
+backslash
+backslash
+leftBrace
+rightBrace
+backslash
+backslash
+backslash
+backslash
+underscore
+leftBrace
+backslash
+rightBrace
+circumflex
+leftBrace
+backslash
+rightBrace
+backslash
+backslash
+circumflex
+leftBrace
+backslash
+backslash
+rightBrace
+backslash
+documentEnd

--- a/tests/testfiles/lunamark-markdown/no-tex-math-single-backslash.test
+++ b/tests/testfiles/lunamark-markdown/no-tex-math-single-backslash.test
@@ -1,0 +1,35 @@
+<<<
+This test ensures that the Lua `texMathSingleBackslash` option is disabled by default.
+
+\(E=mc^2\)
+
+\[\hat{f} \left ( \xi  \right )= \int_{-\infty}^{\infty} f\left ( x  \right ) e^{-i2\pi \xi x} dx\]
+>>>
+documentBegin
+codeSpan: texMathSingleBackslash
+interblockSeparator
+circumflex
+interblockSeparator
+backslash
+leftBrace
+rightBrace
+backslash
+backslash
+backslash
+backslash
+underscore
+leftBrace
+backslash
+rightBrace
+circumflex
+leftBrace
+backslash
+rightBrace
+backslash
+backslash
+circumflex
+leftBrace
+backslash
+backslash
+rightBrace
+documentEnd

--- a/tests/testfiles/lunamark-markdown/tex-math-dollars.test
+++ b/tests/testfiles/lunamark-markdown/tex-math-dollars.test
@@ -15,13 +15,13 @@ $E=mc^2$
 
 $$\hat{f} \left ( \xi  \right )= \int_{-\infty}^{\infty} f\left ( x  \right ) e^{-i2\pi \xi x} dx$$
 
-to produce inline and display math both beginning and ending dollar signs must be present
+To produce inline and display math, both beginning and ending dollar signs must be present:
 
 $2.56
 
 $$2.56
 
-no spaces are allowed at the beginning or end of the inline math
+No spaces are allowed at the beginning or the end of inline math:
 
 $ \infty $
 
@@ -29,11 +29,11 @@ unless they are escaped
 
 $\ $
 
-this is not inline math, because the closing dollar sign is followed by a digit
+The following is not inline math, because the closing dollar sign is followed by a digit:
 
 $a$0
 
-both inline and display math may span multiple lines, but cannot contain a blank line
+Both inline and display math may span multiple lines, but cannot contain blank lines:
 
 $a
 b
@@ -57,22 +57,22 @@ $$
 
 $$$$
 
-note that this is a display math
+The following is display math:
 
 $$
 $$
 
-no unescaped dollar signs are allowed 
+Non-escaped dollar signs will always start inline and display math:
 
 $.$.$
 
 $$.$.$$
 
-escaped dollar signs are allowed
+Escaped dollar signs will not start inline or display math:
 
 $\$$
 
-note that this is an escaped dollar sign in a display math
+The following is an escaped dollar sign inside display math:
 
 $$\$$$
 

--- a/tests/testfiles/lunamark-markdown/tex-math-double-backslash.test
+++ b/tests/testfiles/lunamark-markdown/tex-math-double-backslash.test
@@ -1,0 +1,80 @@
+\def\markdownOptionTexMathDoubleBackslash{true}
+\let\hat=\relax
+\let\left=\relax
+\let\xi=\relax
+\let\right=\relax
+\let\int=\relax
+\let\infty=\relax
+\let\pi=\relax
+\let\\=\relax
+<<<
+This test ensures that the Lua `texMathDoubleBackslash` option correctly propagates
+through the plain TeX interface.
+
+\\(E=mc^2\\)
+
+\\[\hat{f} \left ( \xi  \right )= \int_{-\infty}^{\infty} f\left ( x  \right ) e^{-i2\pi \xi x} dx\\]
+
+Inline or display math may not be empty:
+
+\\(\\)
+
+\\[\\]
+
+Inline or display math may not contain any blank lines:
+
+\\(a
+
+c\\)
+
+\\[a
+
+c\\]
+
+No spaces are allowed at the beginning or the end of inline math:
+
+\\( \infty \\)
+
+Escaped spaces are allowed at the beginning or the end of inline math:
+
+\\(\ \\)
+
+The following is not inline math:
+
+\\\(a\\\)
+>>>
+documentBegin
+codeSpan: texMathDoubleBackslash
+interblockSeparator
+inlineMath: E=mc^2
+interblockSeparator
+displayMath: \hat {f} \left  ( \xi   \right  )= \int _{-\infty }^{\infty } f\left  ( x  \right  ) e^{-i2\pi  \xi  x} dx
+interblockSeparator
+interblockSeparator
+backslash
+backslash
+interblockSeparator
+backslash
+backslash
+interblockSeparator
+interblockSeparator
+backslash
+interblockSeparator
+backslash
+interblockSeparator
+backslash
+interblockSeparator
+backslash
+interblockSeparator
+interblockSeparator
+backslash
+backslash
+backslash
+interblockSeparator
+interblockSeparator
+inlineMath: \ 
+interblockSeparator
+interblockSeparator
+backslash
+backslash
+documentEnd

--- a/tests/testfiles/lunamark-markdown/tex-math-single-and-double-backslashes.test
+++ b/tests/testfiles/lunamark-markdown/tex-math-single-and-double-backslashes.test
@@ -1,0 +1,37 @@
+\def\markdownOptionTexMathDoubleBackslash{true}
+\def\markdownOptionTexMathSingleBackslash{true}
+\let\\=\relax
+<<<
+This test ensures that the Lua `texMathDoubleBackslash` and `texMathSingleBackslash` options correctly propagate
+through the plain TeX interface.
+
+\(a\\)
+
+\[a\\]
+
+\\(a\)
+
+\\[a\]
+
+\\\(a\\\)
+
+\\\[a\\\]
+>>>
+documentBegin
+codeSpan: texMathDoubleBackslash
+codeSpan: texMathSingleBackslash
+interblockSeparator
+backslash
+interblockSeparator
+backslash
+interblockSeparator
+backslash
+interblockSeparator
+backslash
+interblockSeparator
+backslash
+inlineMath: a\\
+interblockSeparator
+backslash
+displayMath: a\\
+documentEnd

--- a/tests/testfiles/lunamark-markdown/tex-math-single-backslash.test
+++ b/tests/testfiles/lunamark-markdown/tex-math-single-backslash.test
@@ -1,0 +1,70 @@
+\def\markdownOptionTexMathSingleBackslash{true}
+\let\hat=\relax
+\let\left=\relax
+\let\xi=\relax
+\let\right=\relax
+\let\int=\relax
+\let\infty=\relax
+\let\pi=\relax
+\let\\=\relax
+<<<
+This test ensures that the Lua `texMathSingleBackslash` option correctly propagates
+through the plain TeX interface.
+
+\(E=mc^2\)
+
+\[\hat{f} \left ( \xi  \right )= \int_{-\infty}^{\infty} f\left ( x  \right ) e^{-i2\pi \xi x} dx\]
+
+Inline or display math may not be empty:
+
+\(\)
+
+\[\]
+
+Inline or display math may not contain any blank lines:
+
+\(a
+
+c\)
+
+\[a
+
+c\]
+
+No spaces are allowed at the beginning or the end of inline math:
+
+\( \infty \)
+
+Escaped spaces are allowed at the beginning or the end of inline math:
+
+\(\ \)
+
+The following is inline math with two backslashes:
+
+\\\(a\\\)
+>>>
+documentBegin
+codeSpan: texMathSingleBackslash
+interblockSeparator
+inlineMath: E=mc^2
+interblockSeparator
+displayMath: \hat {f} \left  ( \xi   \right  )= \int _{-\infty }^{\infty } f\left  ( x  \right  ) e^{-i2\pi  \xi  x} dx
+interblockSeparator
+interblockSeparator
+interblockSeparator
+interblockSeparator
+interblockSeparator
+interblockSeparator
+interblockSeparator
+interblockSeparator
+interblockSeparator
+interblockSeparator
+backslash
+interblockSeparator
+interblockSeparator
+inlineMath: \ 
+interblockSeparator
+interblockSeparator
+backslash
+inlineMath: a\\
+documentEnd


### PR DESCRIPTION
This pull request merges the latest branch `main` from the witiko/markdown repo after merging witiko#256 (attributes on links, images, and inline code spans, see [the changes][2]), which constitutes the last syntax extension planned until version 3.0.0 (to be released in May, see [milestones][1]). Collisions with #128 and #140 should be expected.

 [1]: https://github.com/Witiko/markdown/milestones
 [2]: https://github.com/Witiko/markdown/pull/256/files#diff-285b8cf03357c565a57cd38996790dd7ac052721f2c61e780212489ca60f6dd0