### PR TITLE
Link and emphasis joining

### DIFF
--- a/markdown.dtx
+++ b/markdown.dtx
@@ -24604,11 +24604,6 @@ function M.reader.new(writer, options)
                        return parsers.inlines
                      end, false)
 
-  self.create_parser("parse_inlines_full_link_and_image",
-                     function()
-                       return parsers.inlines_full_link_and_image
-                     end, false)
-
   self.create_parser("parse_inlines_no_inline_note",
                      function()
                        return parsers.inlines_no_inline_note
@@ -24624,9 +24619,9 @@ function M.reader.new(writer, options)
                        return parsers.inlines_nbsp
                      end, false)
 
-  self.create_parser("parse_inlines_no_link_or_image",
+  self.create_parser("parse_inlines_no_link_or_emphasis",
                     function()
-                      return parsers.inlines_no_link_or_image
+                      return parsers.inlines_no_link_or_emphasis
                     end, false)
 %    \end{macrocode}
 % \par
@@ -25258,9 +25253,16 @@ function M.reader.new(writer, options)
 % \end{markdown}
 %  \begin{macrocode}
 
+%  \end{macrocode}
+% \begin{markdown}
+%
+% Parse the content of a table `content_part` with links, images and emphasis disabled.
+%
+% \end{markdown}
+%  \begin{macrocode}
   local function parse_content_part(content_part)
     local rope = util.rope_to_string(content_part)
-    local parsed = self.parser_functions.parse_inlines_no_link_or_image(rope)
+    local parsed = self.parser_functions.parse_inlines_no_link_or_emphasis(rope)
     parsed.indent_info = nil
     return parsed
   end
@@ -26959,16 +26961,11 @@ end
     inlines_nbsp_t.Space = parsers.NonbreakingSpace
     parsers.inlines_nbsp = Ct(inlines_nbsp_t)
 
-    local inlines_full_link_and_image_t = util.table_copy(inlines_t)
-    inlines_full_link_and_image_t.MaybeLinkAndEmph = parsers.fail
-    inlines_full_link_and_image_t.LinkAndEmph = parsers.LinkAndEmph
-    parsers.inlines_full_link_and_image = Ct(inlines_full_link_and_image_t)
-
-    local inlines_no_link_or_image_t = util.table_copy(inlines_t)
-    inlines_no_link_or_image_t.MaybeLinkAndEmph = parsers.fail
-    inlines_no_link_or_image_t.LinkAndEmph = parsers.fail
-    inlines_no_link_or_image_t.EndlineExceptions = parsers.EndlineExceptionsInside
-    parsers.inlines_no_link_or_image = Ct(inlines_no_link_or_image_t)
+    local inlines_no_link_or_emphasis_t = util.table_copy(inlines_t)
+    inlines_no_link_or_emphasis_t.MaybeLinkAndEmph = parsers.fail
+    inlines_no_link_or_emphasis_t.LinkAndEmph = parsers.fail
+    inlines_no_link_or_emphasis_t.EndlineExceptions = parsers.EndlineExceptionsInside
+    parsers.inlines_no_link_or_emphasis = Ct(inlines_no_link_or_emphasis_t)
 %    \end{macrocode}
 % \par
 % \begin{markdown}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -26192,6 +26192,7 @@ function M.reader.new(writer, options)
                                            / (options.hardLineBreaks
                                               and writer.hard_line_break
                                                or writer.space)
+                     + parsers.spacechar^1 * parsers.Endline^-1 * parsers.eof / self.expandtabs
                      + parsers.spacechar^1 * parsers.Endline
                                            / writer.space
                      + parsers.spacechar^1 * -parsers.newline / self.expandtabs

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -25285,17 +25285,17 @@ function M.reader.new(writer, options)
         content[#content + 1] = value.rendered
         value.rendered = nil
       else
-        if value.is_active then
-          if value.type == "delimiter" and value.element == "emphasis" then
+        if value.type == "delimiter" and value.element == "emphasis" then
+          if value.is_active then
             content[#content + 1] = parse_content_part(content_part)
             content_part = {}
             content[#content + 1] = writer.escape(string.rep(value.character, value.current_count))
-          else
-            content_part[#content_part + 1] = value.content
-            value.content = ''
           end
-          value.is_active = false
+        else
+          content_part[#content_part + 1] = value.content
+          value.content = ''
         end
+        value.is_active = false
       end
     end
 
@@ -25361,6 +25361,7 @@ function M.reader.new(writer, options)
       local value = t[i]
       if value.is_active and
          value.is_opening and
+         value.element == "emphasis" and
          (value.character == character) and
          (value.current_count > 0) then
         if not breaks_three_rule(value, closing_delimiter) then
@@ -25831,26 +25832,6 @@ function M.reader.new(writer, options)
         end
       else
         content[#content + 1] = value.content
-        t[i].is_active = false
-      end
-    end
-    return content
-  end
-
-%    \end{macrocode}
-% \begin{markdown}
-%
-% Collect the parsed content between the `opening_index` and `closing_index` in the delimiter table `t`.
-%
-% \end{markdown}
-%  \begin{macrocode}
-  local function collect_link_parsed_content(t, opening_index, closing_index)
-    local content = {}
-    for i = opening_index, closing_index do
-      local value = t[i]
-      local rendered = value.rendered
-      if (rendered ~= nil) then
-        content[#content + 1] = rendered
       end
     end
     return content
@@ -25867,13 +25848,32 @@ function M.reader.new(writer, options)
   local function find_link_opener(t, bottom_index, latest_index)
     for i = latest_index, bottom_index, -2 do
       local value = t[i]
-      if value.is_opening and 
-         value.end_position == 0 and 
-         not value.part_of_link then
+      if value.is_opening and
+         (value.element == "link" or value.element == "image") 
+         and not value.removed then
         if value.is_active then
-          return i, i
+          return i
         end
-        return nil, i
+        t[i].removed = true
+        return nil
+      end
+    end
+  end
+
+%    \end{macrocode}
+% \begin{markdown}
+%
+% 
+%
+% \end{markdown}
+%  \begin{macrocode}
+  local function find_full_link_next_closer(t, latest_index)
+    for i = latest_index, #t do
+      local value = t[i]
+      if not value.is_opening and
+         value.element == "link" and
+         not value.removed then
+        return i
       end
     end
   end
@@ -25907,8 +25907,7 @@ function M.reader.new(writer, options)
 % \begin{markdown}
 %
 % Disable the delimiters between the `opening_index` and `closing_index` in the delimiter table `t` that are 
-% considered a part of link by marking them inactive with the `is_active` property and as a
-% `part_of_link`.
+% considered a part of link by marking them inactive with the `is_active` property.
 %
 % \end{markdown}
 %  \begin{macrocode}
@@ -25917,7 +25916,9 @@ function M.reader.new(writer, options)
       local value = t[i]
       if value.is_active then
         value.is_active = false
-        value.part_of_link = true
+        if value.type == "delimiter" then
+          value.removed = true
+        end
       end
     end
   end
@@ -26004,9 +26005,8 @@ function M.reader.new(writer, options)
 %
 % \end{markdown}
 %  \begin{macrocode}
-  local function render_link_or_image(t, opening_index, closing_index)
+  local function render_link_or_image(t, opening_index, closing_index, content_end_index)
     local link_r = t[opening_index].reference
-    local link_content_rope = t[opening_index].rope
 
     local url = ""
     if (link_r.url ~= nil) then
@@ -26020,7 +26020,9 @@ function M.reader.new(writer, options)
 
     local attributes = link_r.attributes
 
-    local mapped = self.parser_functions.parse_inlines_full_link_and_image(link_content_rope)
+    process_emphasis(t, opening_index, content_end_index)
+
+    local mapped = collect_emphasis_content(t, opening_index + 1, content_end_index - 1)
 
     if attributes == nil or not next(attributes) then
       attributes = nil
@@ -26035,38 +26037,17 @@ function M.reader.new(writer, options)
       rendered = writer.image(mapped, url, title, attributes)
     end
 
-    local mapped_parentheses = {}
+    t[opening_index].rendered = rendered
+    delete_parsed_content_in_range(t, opening_index + 1, closing_index)
+    empty_content_in_range(t, opening_index + 1, closing_index - 1)
+    disable_previous_link_openers(t, opening_index)
+    disable_range(t, opening_index, closing_index)
+
     if (t[closing_index].is_direct and t[opening_index].link_type ~= "inline") then
-      local resolved_closer = resolve_inline_link_closer(t, closing_index, false)
-      mapped_parentheses = self.parser_functions.parse_inlines_full_link_and_image(resolved_closer)
+      t[closing_index].content = resolve_inline_link_closer(t, closing_index, false)
+    else
+      t[closing_index].content = ''
     end
-
-    t[opening_index].rendered = { rendered, mapped_parentheses }
-    delete_parsed_content_in_range(t, opening_index + 1, closing_index)
-  end
-
-%    \end{macrocode}
-% \begin{markdown}
-%
-% Parse content between two delimiters in the delimiter table `t`. Enclose this content with literal brakcets and 
-% resolve potential dangling parentheses and attributes. 
-% In case of a image opening delimiter, an exclamation mark is also added before the brackets.
-%
-% \end{markdown}
-%  \begin{macrocode}
-  local function render_link_or_image_fallback(t, opening_index, closing_index)
-    local prefix = ""
-    if (t[opening_index].rendered) then
-      prefix = "!"
-    end
-
-    local content = collect_link_content(t, opening_index + 1, closing_index - 1)
-    local content_rope = util.rope_to_string(content)
-
-    local child = self.parser_functions.parse_inlines_full_link_and_image(content_rope)
-    
-    t[opening_index].rendered = {prefix, "[",child,"]", resolve_inline_link_closer(t, closing_index, false)}
-    delete_parsed_content_in_range(t, opening_index + 1, closing_index)
   end
 
 %    \end{macrocode}
@@ -26079,8 +26060,6 @@ function M.reader.new(writer, options)
 %  \begin{macrocode}
   -- compared to other link types, here no reference definition is looked up
   local function resolve_inline_link(t, opening_index, closing_index)
-    local content = collect_link_content(t, opening_index + 1, closing_index - 1)
-    local content_rope = util.rope_to_string(content)
     local parentheses_info = t[closing_index].content.inline_content
 
     local all_attributes = {}
@@ -26098,15 +26077,11 @@ function M.reader.new(writer, options)
       title = parentheses_info.title_content.title
     end
 
-    t[opening_index].is_link = true
-    t[opening_index].rope = content_rope
     t[opening_index].reference = { url = url,
                                    title = title,
-                                   attributes = all_attributes
-                                 }
+                                   attributes = all_attributes }
     
-    disable_previous_link_openers(t, opening_index)
-    disable_range(t, opening_index, closing_index)
+    render_link_or_image(t, opening_index, closing_index, closing_index)
   end
 
 %    \end{macrocode}
@@ -26123,16 +26098,12 @@ function M.reader.new(writer, options)
     local r = self.lookup_reference(content_rope)
 
     if r then 
-      t[opening_index].is_link = true
-      t[opening_index].rope = content_rope
-
       local all_attributes = join_attributes(r.attributes, t, closing_index)
 
       r.attributes = all_attributes
       t[opening_index].reference = r
 
-      disable_previous_link_openers(t, opening_index)
-      disable_range(t, opening_index, closing_index)
+      render_link_or_image(t, opening_index, closing_index, closing_index)
     end
   end
 
@@ -26146,24 +26117,21 @@ function M.reader.new(writer, options)
 %  \begin{macrocode}
   local function resolve_full_link(t, opening_index, closing_index)
     local content = collect_link_content(t, opening_index + 1, closing_index - 1)
-    local next_link_content = collect_link_content(t, closing_index + 3, closing_index + 3)
 
-    local content_rope = util.rope_to_string(content)
+    local full_index_closer = find_full_link_next_closer(t, closing_index + 4)
+    local next_link_content = collect_link_content(t, closing_index + 3, full_index_closer - 1)
+
     local next_link_content_rope = util.rope_to_string(next_link_content)
 
     local r = self.lookup_reference(next_link_content_rope)
 
     if r then 
-      t[opening_index].is_link = true
-      t[opening_index].rope = content_rope
-
-      local all_attributes = join_attributes(r.attributes, t, closing_index + 4)
+      local all_attributes = join_attributes(r.attributes, t, full_index_closer)
 
       r.attributes = all_attributes
       t[opening_index].reference = r
 
-      disable_previous_link_openers(t, opening_index)
-      disable_range(t, opening_index, closing_index + 4)
+      render_link_or_image(t, opening_index, full_index_closer, closing_index)
     end
   end
 
@@ -26181,17 +26149,13 @@ function M.reader.new(writer, options)
 
     local r = self.lookup_reference(content_rope)
 
-    if r then 
-      t[opening_index].is_link = true
-      t[opening_index].rope = content_rope
-      
+    if r then       
       local all_attributes = join_attributes(r.attributes, t, closing_index)
 
       r.attributes = all_attributes
       t[opening_index].reference = r
       
-      disable_previous_link_openers(t, opening_index)
-      disable_range(t, opening_index, closing_index)
+      render_link_or_image(t, opening_index, closing_index, closing_index)
     end
   end
 
@@ -26199,11 +26163,9 @@ function M.reader.new(writer, options)
 % \begin{markdown}
 %
 % Parse a table of link and emphasis delimiters `delimiter_table`.
-% Iterate over the delimiters in the delimiter table `t` in two passes. First, the delimiters either 
-% marked as links (or images) with the `is_link` property, additionally assigned a closing delimiter. 
-% Secondly, the content of the resolved links is parsed, with respective macros produced. 
-% Any delimiters that do not form links are returned as is (fallback), with their content also recursively
-% parsed.
+% First, iterate over the link delimiters and produce either link or image macros. 
+% Then run process emphasis over the entire delimiter table, resolving emphasis and
+% parsing any content outside of closed delimiters.
 %
 % \end{markdown}
 %  \begin{macrocode}
@@ -26211,24 +26173,20 @@ function M.reader.new(writer, options)
     local t = delimiter_table[1]
     for _,value in ipairs(t) do
       value.is_active = true
-      if (value.is_opening and value.type == "delimiter" and (value.element == "link" or value.element == "image")) then
-        value.is_link = false
-        value.end_position = 0
-      end
     end
     local current_position = 1
 
-    -- iterate over delimiters, marking links
+    -- iterate over delimiters, rendering links and images
     while current_position <= #t do
       local value = t[current_position]
 
       if not value.is_opening and value.type == "delimiter" and (value.element == "link" or value.element == "image") then
-        local opener_position, non_active_opener_position = find_link_opener(t, 1, current_position - 2)
-        local end_position = current_position
+
+        local opener_position = find_link_opener(t, 1, current_position - 2)
 
         if (opener_position ~= nil) then
           local opening_delimiter = t[opener_position]
-          opening_delimiter.end_position = current_position
+          t[opener_position].removed = true
 
           local link_type = opening_delimiter.link_type
           
@@ -26240,70 +26198,26 @@ function M.reader.new(writer, options)
           end
           if (link_type == "full") then
             resolve_full_link(t, opener_position, current_position)
-
-            -- skip next label if matched
-            if (opening_delimiter.is_link) then
-              current_position = current_position + 4
-              end_position = end_position + 4
-            end
           end
           if (link_type == "collapsed") then
             resolve_collapsed_link(t, opener_position, current_position)
-
-            -- skip next label if matched
-            if (opening_delimiter.is_link) then
-              current_position = current_position + 4
-              end_position = end_position + 4
-            end
           end
+        end
 
-          opening_delimiter.end_position = end_position
-        else
-          if (non_active_opener_position ~= nil) then
-            t[non_active_opener_position].end_position = current_position
-          end
+        if not t[current_position].removed and t[current_position].is_direct then
+          t[current_position].content = resolve_inline_link_closer(t, current_position, true)
         end
       end
       current_position = current_position + 2
     end
 
-    current_position = 1
-    -- iterate over found links, parsing content
-    while current_position <= #t do
-      local delimiter = t[current_position]
 
-      if delimiter.is_opening and delimiter.type == "delimiter" and delimiter.is_link then
-        local end_position = delimiter.end_position
-        render_link_or_image(t, current_position, end_position)
+    process_emphasis(t, 1, #t)
 
-        current_position = end_position
-      end
-      current_position = current_position + 2
-    end
-    current_position = 1
 
-    -- iterate over content, restoring activeness
-    while current_position <= #t do
-      local item = t[current_position]
-      item.is_active = true
-
-      if item.type == "delimiter" and (item.element == "link" or item.element == "image") then
-        if item.is_opening and item.is_link then
-
-          local end_position = item.end_position
-          empty_content_in_range(t, current_position, end_position) -- remove self content too
-
-          current_position = end_position
-        end
-        if item.is_direct then
-          item.content = resolve_inline_link_closer(t, current_position, true)
-        end
-      end
-      current_position = current_position + 1
-    end
-
-    local emph_t = process_emphasis(t, 1, #t)
     local final_result = collect_emphasis_content(t, 1, #t)
+
+
     return final_result
   end
 

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -25360,10 +25360,11 @@ function M.reader.new(writer, options)
 % \end{markdown}
 %  \begin{macrocode}
   local function find_emphasis_opener(t, bottom_index, latest_index, character, closing_delimiter)
-    for i = latest_index, bottom_index, -2 do
+    for i = latest_index, bottom_index, -1 do
       local value = t[i]
       if value.is_active and
          value.is_opening and
+         value.type == "delimiter" and
          value.element == "emphasis" and
          (value.character == character) and
          (value.current_count > 0) then
@@ -25424,7 +25425,7 @@ function M.reader.new(writer, options)
 
       local current_openers_bottom = openers_bottom[character][is_opening][closing_length_modulo_three + 1]
 
-      local opener_position = find_emphasis_opener(t, current_openers_bottom, current_position - 2, character, value)
+      local opener_position = find_emphasis_opener(t, current_openers_bottom, current_position - 1, character, value)
 
       if (opener_position == nil) then
         openers_bottom[character][is_opening][closing_length_modulo_three + 1] = current_position
@@ -25634,9 +25635,11 @@ function M.reader.new(writer, options)
                               attributes)
     local normalized_tag = self.normalize_tag(tag)
       if references[normalized_tag] == nil then
-        references[normalized_tag] = { url = url, 
-                                       title = title,
-                                       attributes = attributes }
+        references[normalized_tag] = {
+          url = url,
+          title = title,
+          attributes = attributes
+        }
       end
     return ""
   end
@@ -25740,19 +25743,18 @@ function M.reader.new(writer, options)
                                 + parsers.autolink
 
   parsers.link_and_emph_content = Ct( Cg(Cc("content"), "type")
-                                  * Cg(Cs((
-                                          parsers.link_emph_precedence 
-                                          + parsers.backslash^-1 * parsers.any
-                                          - parsers.blankline^2
-                                          - parsers.link_image_open_or_close 
-                                          - parsers.emph_open_or_close)^0), "content"))
+                                    * Cg(Cs(( parsers.link_emph_precedence 
+                                            + parsers.backslash^-1 * parsers.any
+                                            - parsers.blankline^2
+                                            - parsers.link_image_open_or_close 
+                                            - parsers.emph_open_or_close)^0), "content"))
 
   parsers.link_and_emph_table = (parsers.link_image_opening + parsers.emph_open)
                               * parsers.link_and_emph_content
                               * ((parsers.link_image_open_or_close + parsers.emph_open_or_close)
                                 * parsers.link_and_emph_content)^1
 
-%    \end{macrocode}
+%  \end{macrocode}
 % \begin{markdown}
 %
 % Collect the content between the `opening_index` and `closing_index` in the delimiter table `t`.
@@ -25767,18 +25769,19 @@ function M.reader.new(writer, options)
     return util.rope_to_string(content)
   end
 
-%    \end{macrocode}
+%  \end{macrocode}
 % \begin{markdown}
 %
-% Look for the first potential unexplored link opener in the delimiter table `t` in the range from
+% Look for the closest potential link opener in the delimiter table `t` in the range from
 % `bottom_index` to `latest_index`.
 %
 % \end{markdown}
 %  \begin{macrocode}
   local function find_link_opener(t, bottom_index, latest_index)
-    for i = latest_index, bottom_index, -2 do
+    for i = latest_index, bottom_index, -1 do
       local value = t[i]
-      if value.is_opening and
+      if value.type == "delimiter" and
+         value.is_opening and
          (value.element == "link" or value.element == "image") 
          and not value.removed then
         if value.is_active then
@@ -25790,10 +25793,11 @@ function M.reader.new(writer, options)
     end
   end
 
-%    \end{macrocode}
+%  \end{macrocode}
 % \begin{markdown}
 %
-% 
+% Find the position of a delimiter that closes a full link after an an index `latest_index`
+% in the delimiter table `t`.
 %
 % \end{markdown}
 %  \begin{macrocode}
@@ -25808,21 +25812,20 @@ function M.reader.new(writer, options)
     end
   end
 
-%    \end{macrocode}
+%  \end{macrocode}
 % \begin{markdown}
 %
-% Disable all previously encountered opening delimiters by marking them inactive with the `is_active` property
+% Disable all preceding opening link delimiters by marking them inactive with the `is_active` property
 % to prevent links within links. Images within links are allowed.
-% This process starts from `index` and continues to the start of the delimiter table `t`.
 %
 % \end{markdown}
 %  \begin{macrocode}
-  local function disable_previous_link_openers(t, index)
-    if t[index].element == "image" then
+  local function disable_previous_link_openers(t, opening_index)
+    if t[opening_index].element == "image" then
       return
     end
 
-    for i = index, 1, -1 do
+    for i = opening_index, 1, -1 do
       local value = t[i]
       if value.is_active and
          value.type == "delimiter" and
@@ -25833,7 +25836,7 @@ function M.reader.new(writer, options)
     end
   end
 
-%    \end{macrocode}
+%  \end{macrocode}
 % \begin{markdown}
 %
 % Disable the delimiters between the `opening_index` and `closing_index` in the delimiter table `t`
@@ -25853,7 +25856,7 @@ function M.reader.new(writer, options)
     end
   end
 
-%    \end{macrocode}
+%  \end{macrocode}
 % \begin{markdown}
 %
 % Clear the parsed content between the `opening_index` and `closing_index` in the delimiter table `t`.
@@ -25866,7 +25869,7 @@ function M.reader.new(writer, options)
     end
   end
 
-%    \end{macrocode}
+%  \end{macrocode}
 % \begin{markdown}
 %
 % Clear the content between the `opening_index` and `closing_index` in the delimiter table `t`.
@@ -25879,7 +25882,7 @@ function M.reader.new(writer, options)
     end
   end
 
-%    \end{macrocode}
+%  \end{macrocode}
 % \begin{markdown}
 %
 % Join the attributes from the link reference definition `reference_attributes` with the link's own
@@ -25888,24 +25891,20 @@ function M.reader.new(writer, options)
 % \end{markdown}
 %  \begin{macrocode}
   local function join_attributes(reference_attributes, own_attributes)
-    local joined_attributes = reference_attributes
-    if joined_attributes == nil then
-      joined_attributes = {}
+    local merged_attributes = {}
+    for _, attribute in ipairs(reference_attributes or {}) do
+      table.insert(merged_attributes, attribute)
     end
-
-    if own_attributes ~= nil then
-      for _, attribute in ipairs(own_attributes) do
-        table.insert(joined_attributes, attribute)
-      end
+    for _, attribute in ipairs(own_attributes or {}) do
+      table.insert(merged_attributes, attribute)
     end
-    
-    if not next(joined_attributes) then
-      return nil
+    if next(merged_attributes) == nil then
+      merged_attributes = nil
     end
-    return joined_attributes
+    return merged_attributes
   end
 
-%    \end{macrocode}
+%  \end{macrocode}
 % \begin{markdown}
 %
 % Parse content between two delimiters in the delimiter table `t`. Produce the respective link and image 
@@ -25913,28 +25912,17 @@ function M.reader.new(writer, options)
 %
 % \end{markdown}
 %  \begin{macrocode}
-  local function render_link_or_image(t, opening_index, closing_index, content_end_index)
-    local link_r = t[opening_index].reference
-
-    local url = link_r.url or ""
-    local title = link_r.title or ""
-    local attributes = link_r.attributes
-
-    if attributes == nil or not next(attributes) then
-      attributes = nil
-    end
-
+  local function render_link_or_image(t, opening_index, closing_index, content_end_index, reference)
     process_emphasis(t, opening_index, content_end_index)
-
     local mapped = collect_emphasis_content(t, opening_index + 1, content_end_index - 1)
 
     local rendered = {}
     if (t[opening_index].element == "link") then
-      rendered = writer.link(mapped, url, title, attributes)
+      rendered = writer.link(mapped, reference.url, reference.title, reference.attributes)
     end
 
     if (t[opening_index].element == "image") then
-      rendered = writer.image(mapped, url, title, attributes)
+      rendered = writer.image(mapped, reference.url, reference.title, reference.attributes)
     end
 
     t[opening_index].rendered = rendered
@@ -25944,11 +25932,11 @@ function M.reader.new(writer, options)
     disable_range(t, opening_index, closing_index)
   end
 
-%    \end{macrocode}
+%  \end{macrocode}
 % \begin{markdown}
 %
 % Match the link destination of an inline link at index `closing_index` in table `t`
-% when `match_reference` is true. Additionally match attributes when the option
+% when `match_reference` is true. Additionally, match attributes when the option
 % \Opt{linkAttributes} is enabled.
 %
 % \end{markdown}
@@ -25974,26 +25962,32 @@ function M.reader.new(writer, options)
     local matched_count = matched.end_position - 1
     for i = closing_index + 1, #t do
       local value = t[i]
-      value.is_active = false
-      local current = value.content
-      value.content = ''
 
       local chars_left = matched_count
-      matched_count = matched_count - #current
+      matched_count = matched_count - #value.content
 
       if matched_count <= 0 then
-        local s = current:sub(chars_left + 1)
-        value.content = s
+        value.content = value.content:sub(chars_left + 1)
         break
       end
+
+      value.content = ''
+      value.is_active = false
     end
 
-    return { url = matched.url,
-            title = matched.title,
-            attributes = matched.attributes }
+    local attributes = matched.attributes
+    if attributes == nil or next(attributes) == nil then
+      attributes = nil
+    end
+
+    return {
+      url = matched.url or "",
+      title = matched.title or "",
+      attributes = attributes
+    }
   end
 
-%    \end{macrocode}
+%  \end{macrocode}
 % \begin{markdown}
 %
 % Resolve an inline link [a](b "c") from the delimiters at `opening_index` and `closing_index` within a delimiter table `t`.
@@ -26003,11 +25997,10 @@ function M.reader.new(writer, options)
 %  \begin{macrocode}
   local function resolve_inline_link(t, opening_index, closing_index)
     local inline_content = resolve_inline_following_content(t, closing_index, true, t.match_link_attributes)
-    t[opening_index].reference = inline_content
-    render_link_or_image(t, opening_index, closing_index, closing_index)
+    render_link_or_image(t, opening_index, closing_index, closing_index, inline_content)
   end
 
-%    \end{macrocode}
+%  \end{macrocode}
 % \begin{markdown}
 %
 % Resolve a shortcut link [a] from the delimiters at `opening_index` and `closing_index` within a delimiter table `t`.
@@ -26021,15 +26014,12 @@ function M.reader.new(writer, options)
 
     if r then
       local inline_content = resolve_inline_following_content(t, closing_index, false, t.match_link_attributes)
-
       r.attributes = join_attributes(r.attributes, inline_content.attributes)
-      t[opening_index].reference = r
-
-      render_link_or_image(t, opening_index, closing_index, closing_index)
+      render_link_or_image(t, opening_index, closing_index, closing_index, r)
     end
   end
 
-%    \end{macrocode}
+%  \end{macrocode}
 % \begin{markdown}
 %
 % Resolve a full link [a][b] from the delimiters at `opening_index` and `closing_index` within a delimiter table `t`.
@@ -26040,20 +26030,16 @@ function M.reader.new(writer, options)
   local function resolve_full_link(t, opening_index, closing_index)
     local next_link_closing_index = find_next_link_closing_index(t, closing_index + 4)
     local next_link_content = collect_link_content(t, closing_index + 3, next_link_closing_index - 1)
-
     local r = self.lookup_reference(next_link_content)
 
     if r then
       local inline_content = resolve_inline_following_content(t, next_link_closing_index, false, t.match_link_attributes)
-
       r.attributes = join_attributes(r.attributes, inline_content.attributes)
-      t[opening_index].reference = r
-
-      render_link_or_image(t, opening_index, next_link_closing_index, closing_index)
+      render_link_or_image(t, opening_index, next_link_closing_index, closing_index, r)
     end
   end
 
-%    \end{macrocode}
+%  \end{macrocode}
 % \begin{markdown}
 %
 % Resolve a collapsed link [a][] from the delimiters at `opening_index` and `closing_index` within a delimiter table `t`.
@@ -26067,21 +26053,18 @@ function M.reader.new(writer, options)
 
     if r then
       local inline_content = resolve_inline_following_content(t, closing_index, false, t.match_link_attributes)
-
       r.attributes = join_attributes(r.attributes, inline_content.attributes)
-      t[opening_index].reference = r
-      
-      render_link_or_image(t, opening_index, closing_index, closing_index)
+      render_link_or_image(t, opening_index, closing_index, closing_index, r)
     end
   end
 
-%    \end{macrocode}
+%  \end{macrocode}
 % \begin{markdown}
 %
 % Parse a table of link and emphasis delimiters `t`.
 % First, iterate over the link delimiters and produce either link or image macros. 
-% Then run process emphasis over the entire delimiter table, resolving emphasis and
-% parsing any content outside of closed delimiters.
+% Then run `process_emphasis` over the entire delimiter table, resolving emphasis and strong
+% emphasis and parsing any content outside of closed delimiters.
 %
 % \end{markdown}
 %  \begin{macrocode}
@@ -26090,16 +26073,14 @@ function M.reader.new(writer, options)
       value.is_active = true
     end
 
-    for i = 1, #t do
-      local value = t[i]
-
+    for i,value in ipairs(t) do
       if not value.is_closing or 
         value.type ~= "delimiter" or 
         not (value.element == "link" or value.element == "image") then
         goto continue
       end
 
-      local opener_position = find_link_opener(t, 1, i - 2)
+      local opener_position = find_link_opener(t, 1, i - 1)
       if (opener_position == nil) then
         goto continue
       end

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -25354,7 +25354,8 @@ function M.reader.new(writer, options)
 % \begin{markdown}
 %
 % Look for the first potential emphasis opener in the delimiter table `t` in the range from
-% `bottom_index` to `latest_index`.
+% `bottom_index` to `latest_index` that has the same character `character` as the closing
+% delimiter `closing_delimiter`.
 %
 % \end{markdown}
 %  \begin{macrocode}
@@ -25392,8 +25393,8 @@ function M.reader.new(writer, options)
     end
 
     local openers_bottom = {
-      ['*'] = { -- character
-        [true] = {opening_index, opening_index, opening_index}, -- is opening
+      ['*'] = {
+        [true] = {opening_index, opening_index, opening_index},
         [false] = {opening_index, opening_index, opening_index}
       },
       ['_'] = {
@@ -25597,9 +25598,6 @@ function M.reader.new(writer, options)
   parsers.emph_close  = parsers.emph_capturing_open_and_close
                       + parsers.emph_capturing_close
 
-  parsers.emph_content  = Ct( Cg(Cc("content"), "type")
-                            * Cg(Ct((parsers.Inline - parsers.emph_open_or_close)^0), "content"))
-
 %    \end{macrocode}
 % \par
 % \begin{markdown}
@@ -25749,15 +25747,15 @@ function M.reader.new(writer, options)
                                           - parsers.link_image_open_or_close 
                                           - parsers.emph_open_or_close)^0), "content"))
 
-  parsers.link_and_emph_table = Ct((parsers.link_image_opening + parsers.emph_open)
-                                  * parsers.link_and_emph_content
-                                  * ((parsers.link_image_open_or_close + parsers.emph_open_or_close)
-                                    * parsers.link_and_emph_content)^1)
+  parsers.link_and_emph_table = (parsers.link_image_opening + parsers.emph_open)
+                              * parsers.link_and_emph_content
+                              * ((parsers.link_image_open_or_close + parsers.emph_open_or_close)
+                                * parsers.link_and_emph_content)^1
 
 %    \end{macrocode}
 % \begin{markdown}
 %
-% Collect the raw content between the `opening_index` and `closing_index` in the delimiter table `t`.
+% Collect the content between the `opening_index` and `closing_index` in the delimiter table `t`.
 %
 % \end{markdown}
 %  \begin{macrocode}
@@ -25766,7 +25764,7 @@ function M.reader.new(writer, options)
     for i = opening_index, closing_index do
       content[#content + 1] = t[i].content
     end
-    return content
+    return util.rope_to_string(content)
   end
 
 %    \end{macrocode}
@@ -25786,7 +25784,7 @@ function M.reader.new(writer, options)
         if value.is_active then
           return i
         end
-        t[i].removed = true
+        value.removed = true
         return nil
       end
     end
@@ -25799,7 +25797,7 @@ function M.reader.new(writer, options)
 %
 % \end{markdown}
 %  \begin{macrocode}
-  local function find_full_link_next_closer(t, latest_index)
+  local function find_next_link_closing_index(t, latest_index)
     for i = latest_index, #t do
       local value = t[i]
       if value.is_closing and
@@ -25838,8 +25836,8 @@ function M.reader.new(writer, options)
 %    \end{macrocode}
 % \begin{markdown}
 %
-% Disable the delimiters between the `opening_index` and `closing_index` in the delimiter table `t` that are 
-% considered a part of link by marking them inactive with the `is_active` property.
+% Disable the delimiters between the `opening_index` and `closing_index` in the delimiter table `t`
+% by marking them inactive with the `is_active` property.
 %
 % \end{markdown}
 %  \begin{macrocode}
@@ -25871,7 +25869,7 @@ function M.reader.new(writer, options)
 %    \end{macrocode}
 % \begin{markdown}
 %
-% Clear the parsed content between the `opening_index` and `closing_index` in the delimiter table `t`.
+% Clear the content between the `opening_index` and `closing_index` in the delimiter table `t`.
 %
 % \end{markdown}
 %  \begin{macrocode}
@@ -25911,7 +25909,7 @@ function M.reader.new(writer, options)
 % \begin{markdown}
 %
 % Parse content between two delimiters in the delimiter table `t`. Produce the respective link and image 
-% macros and resolve potential dangling parentheses and attributes. 
+% macros. 
 %
 % \end{markdown}
 %  \begin{macrocode}
@@ -25955,44 +25953,45 @@ function M.reader.new(writer, options)
 %
 % \end{markdown}
 %  \begin{macrocode}
-  local function resolve_inline_following_content(t, closing_index, match_reference, match_attributes)
+  local function resolve_inline_following_content(t, closing_index, match_reference, match_link_attributes)
     local content = ""
     for i = closing_index + 1, #t do
       content = content .. t[i].content
     end
 
-  local matching_content = parsers.succeed
+    local matching_content = parsers.succeed
 
-  if match_reference then
-    matching_content = matching_content * parsers.inline_direct_ref
-  end
-
-  if match_attributes then
-    matching_content = matching_content * Cg(Ct(parsers.attributes^-1), "attributes")
-  end
-
-  local matched = lpeg.match(Ct(matching_content * Cg(Cp(), "end_position")), content)
-
-  local matched_count = matched.end_position - 1
-  for i = closing_index + 1, #t do
-    t[i].is_active = false
-    local current = t[i].content
-    t[i].content = ''
-
-    local chars_left = matched_count
-    matched_count = matched_count - #current
-
-    if matched_count <= 0 then
-      local s = current:sub(chars_left + 1)
-      t[i].content = s
-      break
+    if match_reference then
+      matching_content = matching_content * parsers.inline_direct_ref
     end
-  end
 
-  return { url = matched.url, 
-           title = matched.title, 
-           attributes = matched.attributes }
-end
+    if match_link_attributes then
+      matching_content = matching_content * Cg(Ct(parsers.attributes^-1), "attributes")
+    end
+
+    local matched = lpeg.match(Ct(matching_content * Cg(Cp(), "end_position")), content)
+
+    local matched_count = matched.end_position - 1
+    for i = closing_index + 1, #t do
+      local value = t[i]
+      value.is_active = false
+      local current = value.content
+      value.content = ''
+
+      local chars_left = matched_count
+      matched_count = matched_count - #current
+
+      if matched_count <= 0 then
+        local s = current:sub(chars_left + 1)
+        value.content = s
+        break
+      end
+    end
+
+    return { url = matched.url,
+            title = matched.title,
+            attributes = matched.attributes }
+  end
 
 %    \end{macrocode}
 % \begin{markdown}
@@ -26002,12 +26001,9 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-  -- compared to other link types, here no reference definition is looked up
   local function resolve_inline_link(t, opening_index, closing_index)
-    local inline_content = resolve_inline_following_content(t, closing_index, true, t.match_attributes)
-
+    local inline_content = resolve_inline_following_content(t, closing_index, true, t.match_link_attributes)
     t[opening_index].reference = inline_content
-    
     render_link_or_image(t, opening_index, closing_index, closing_index)
   end
 
@@ -26021,15 +26017,12 @@ end
 %  \begin{macrocode}
   local function resolve_shortcut_link(t, opening_index, closing_index)
     local content = collect_link_content(t, opening_index + 1, closing_index - 1)
-    local content_rope = util.rope_to_string(content)
-    local r = self.lookup_reference(content_rope)
+    local r = self.lookup_reference(content)
 
-    local inline_content = resolve_inline_following_content(t, closing_index, false, t.match_attributes)
+    if r then
+      local inline_content = resolve_inline_following_content(t, closing_index, false, t.match_link_attributes)
 
-    if r then 
-      local all_attributes = join_attributes(r.attributes, inline_content.attributes)
-
-      r.attributes = all_attributes
+      r.attributes = join_attributes(r.attributes, inline_content.attributes)
       t[opening_index].reference = r
 
       render_link_or_image(t, opening_index, closing_index, closing_index)
@@ -26045,24 +26038,18 @@ end
 % \end{markdown}
 %  \begin{macrocode}
   local function resolve_full_link(t, opening_index, closing_index)
-    local content = collect_link_content(t, opening_index + 1, closing_index - 1)
+    local next_link_closing_index = find_next_link_closing_index(t, closing_index + 4)
+    local next_link_content = collect_link_content(t, closing_index + 3, next_link_closing_index - 1)
 
-    local full_index_closer = find_full_link_next_closer(t, closing_index + 4)
-    local next_link_content = collect_link_content(t, closing_index + 3, full_index_closer - 1)
+    local r = self.lookup_reference(next_link_content)
 
-    local next_link_content_rope = util.rope_to_string(next_link_content)
+    if r then
+      local inline_content = resolve_inline_following_content(t, next_link_closing_index, false, t.match_link_attributes)
 
-    local r = self.lookup_reference(next_link_content_rope)
-
-    local inline_content = resolve_inline_following_content(t, full_index_closer, false, t.match_attributes)
-
-    if r then 
-      local all_attributes = join_attributes(r.attributes, inline_content.attributes)
-
-      r.attributes = all_attributes
+      r.attributes = join_attributes(r.attributes, inline_content.attributes)
       t[opening_index].reference = r
 
-      render_link_or_image(t, opening_index, full_index_closer, closing_index)
+      render_link_or_image(t, opening_index, next_link_closing_index, closing_index)
     end
   end
 
@@ -26076,16 +26063,12 @@ end
 %  \begin{macrocode}
   local function resolve_collapsed_link(t, opening_index, closing_index)
     local content = collect_link_content(t, opening_index + 1, closing_index - 1)
-    local content_rope = util.rope_to_string(content)
+    local r = self.lookup_reference(content)
 
-    local r = self.lookup_reference(content_rope)
+    if r then
+      local inline_content = resolve_inline_following_content(t, closing_index, false, t.match_link_attributes)
 
-    local inline_content = resolve_inline_following_content(t, closing_index, false, t.match_attributes)
-
-    if r then       
-      local all_attributes = join_attributes(r.attributes, inline_content.attributes)
-
-      r.attributes = all_attributes
+      r.attributes = join_attributes(r.attributes, inline_content.attributes)
       t[opening_index].reference = r
       
       render_link_or_image(t, opening_index, closing_index, closing_index)
@@ -26095,21 +26078,18 @@ end
 %    \end{macrocode}
 % \begin{markdown}
 %
-% Parse a table of link and emphasis delimiters `delimiter_table`.
+% Parse a table of link and emphasis delimiters `t`.
 % First, iterate over the link delimiters and produce either link or image macros. 
 % Then run process emphasis over the entire delimiter table, resolving emphasis and
 % parsing any content outside of closed delimiters.
 %
 % \end{markdown}
 %  \begin{macrocode}
-  function process_links_and_emphasis(delimiter_table)
-    local t = delimiter_table[1]
-    t.match_attributes = delimiter_table.match_attributes
+  function process_links_and_emphasis(t)
     for _,value in ipairs(t) do
       value.is_active = true
     end
 
-    -- iterate over delimiters, rendering links and images
     for i = 1, #t do
       local value = t[i]
 
@@ -28331,10 +28311,10 @@ M.extensions.link_attributes = function()
 % \end{markdown}
 %  \begin{macrocode}
 
-      local MaybeLinkWithAttributesAndEmph  = Ct(parsers.link_and_emph_table * Cg(Cc(true), "match_attributes"))
+      local MaybeLinkWithAttributesAndEmph  = Ct(parsers.link_and_emph_table * Cg(Cc(true), "match_link_attributes"))
                                               / defer_link_and_emphasis_processing
 
-      local LinkWithAttributesAndEmph       = Ct(parsers.link_and_emph_table * Cg(Cc(true), "match_attributes"))
+      local LinkWithAttributesAndEmph       = Ct(parsers.link_and_emph_table * Cg(Cc(true), "match_link_attributes"))
                                             / process_links_and_emphasis
 
       self.update_rule("MaybeLinkAndEmph", MaybeLinkWithAttributesAndEmph)

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -25648,41 +25648,23 @@ function M.reader.new(writer, options)
     return references[self.normalize_tag(tag)]
   end
 
-  parsers.title_s_with_captures = Cg(C(parsers.squote), "delimiter")
-                                * Cg(Cs(((parsers.anyescaped - parsers.squote - parsers.blankline^2))^0), "title")
-                                * parsers.squote
-
-  parsers.title_d_with_captures = Cg(C(parsers.dquote), "delimiter")
-                                * Cg(Cs(((parsers.anyescaped - parsers.dquote - parsers.blankline^2))^0), "title")
-                                * parsers.dquote
-
-  parsers.title_p_with_captures = Cg(C(parsers.lparent), "delimiter")
-                                * Cg(Cs((parsers.inparens + (parsers.anyescaped - parsers.rparent - parsers.blankline^2))^0), "title")
-                                * parsers.rparent
-
-  parsers.title_with_captures = parsers.title_d_with_captures
-                              + parsers.title_s_with_captures
-                              + parsers.title_p_with_captures
-
-  parsers.link_destination  = Cg(C(parsers.less), "opening")
-                            * Cg(Cs(( parsers.anyescaped
+  parsers.link_destination  = parsers.less
+                            * Cs(( parsers.anyescaped
                                     - parsers.newline
                                     - parsers.less
-                                    - parsers.more)^0), "url")
-                            * Cg(C(parsers.more), "closing")
+                                    - parsers.more)^0)
+                            * parsers.more
                             + -parsers.less
-                            * Cg(Cc(""), "opening")
-                            * Cg(Cs(( parsers.inparens
+                            * Cs(( parsers.inparens
                                 + ( parsers.anyescaped
                                   - parsers.spacing
-                                  - parsers.rparent))^1), "url")
-                            * Cg(Cc(""), "closing")
+                                  - parsers.rparent))^1)
 
-  parsers.inline_direct_ref = Cg(parsers.lparent * parsers.spnl, "start")
-                            * Cg((Ct(parsers.link_destination) + Cc(nil)), "url_content")
-                            * Cg(parsers.spnl, "middle")
-                            * Cg(Ct(parsers.title_with_captures) + Cc(nil), "title_content")
-                            * Cg(parsers.spnl * parsers.rparent, "ending")
+  parsers.inline_direct_ref = parsers.lparent * parsers.spnl
+                            * Cg(parsers.link_destination + Cc(""), "url")
+                            * parsers.spnl
+                            * Cg(parsers.title + Cc(""), "title")
+                            * parsers.spnl * parsers.rparent
 
   parsers.empty_link  = parsers.lbracket
                       * parsers.rbracket
@@ -25728,6 +25710,7 @@ function M.reader.new(writer, options)
 
   parsers.link_image_opening  = Ct( Cg(Cc("delimiter"), "type")
                                   * Cg(Cc(true), "is_opening")
+                                  * Cg(Cc(false), "is_closing")
                                   * ( Cg(Cc("image"), "element")
                                     * parsers.image_opening
                                     * Cg(parsers.exclamation * parsers.lbracket, "content")
@@ -25738,8 +25721,9 @@ function M.reader.new(writer, options)
   parsers.link_image_closing  = Ct( Cg(Cc("delimiter"), "type")
                                   * Cg(Cc("link"), "element")
                                   * Cg(Cc(false), "is_opening")
+                                  * Cg(Cc(true), "is_closing")
                                   * ( Cg(Cc(true), "is_direct")
-                                    * Cg(Ct(C(parsers.rbracket) * Cg(Ct(parsers.inline_direct_ref), "inline_content")), "content")
+                                    * Cg(parsers.rbracket * #parsers.inline_direct_ref, "content")
                                     + Cg(Cc(false), "is_direct")
                                     * Cg(parsers.rbracket, "content")))
 
@@ -25758,60 +25742,9 @@ function M.reader.new(writer, options)
                                           - parsers.emph_open_or_close)^0), "content"))
 
   parsers.link_and_emph_table = Ct((parsers.link_image_opening + parsers.emph_open)
-                                  * ((parsers.link_and_emph_content)
-                                     * (parsers.link_image_open_or_close + parsers.emph_open_or_close))^1)
-
-%    \end{macrocode}
-% \begin{markdown}
-%
-% Return the parentheses of an inline link for a closing delimiter at index `index` in the delimiter table `t`.
-% If the \Opt{linkAttributes} option extension is enabled, then also the attributes are returned.
-% The closing bracket is also included in the return value when `include_bracket` is enabled.
-%
-% \end{markdown}
-%  \begin{macrocode}
-  local function resolve_inline_link_closer(t, index, include_bracket)
-    local value = t[index]
-    if value.type == "delimiter" and (value.element == "link" or value.element == "image") then
-      local inline_content = value.content.inline_content
-      local attribute_content = value.content.attribute_content
-
-      local result = ""
-      if include_bracket then
-        result = value.content[1]
-      end
-
-      if inline_content ~= nil then
-        local url_string = ""
-        local title_string = ""
-
-        if inline_content.url_content ~= nil then
-          local url_content = inline_content.url_content
-          url_string = url_content.opening .. url_content.url .. url_content.closing
-        end
-
-        if inline_content.title_content ~= nil then
-          local title_content = inline_content.title_content
-          title_string = title_content.delimiter .. title_content.title .. title_content.delimiter
-        end
-        
-        result = result ..
-          inline_content.start ..
-          url_string ..
-          inline_content.middle .. 
-          title_string ..
-          inline_content.ending
-      end
-
-      if attribute_content ~= nil then
-        result = result ..
-        attribute_content.opening ..
-        util.rope_to_string(attribute_content.content) ..
-        attribute_content.ending
-      end
-      return result
-    end
-  end
+                                  * parsers.link_and_emph_content
+                                  * ((parsers.link_image_open_or_close + parsers.emph_open_or_close)
+                                    * parsers.link_and_emph_content)^1)
 
 %    \end{macrocode}
 % \begin{markdown}
@@ -25823,16 +25756,7 @@ function M.reader.new(writer, options)
   local function collect_link_content(t, opening_index, closing_index)
     local content = {}
     for i = opening_index, closing_index do
-      local value = t[i]
-      if value.type == "delimiter" and (value.element == "link" or value.element == "image") then
-        if value.is_direct then
-          content[#content + 1] = resolve_inline_link_closer(t, i, true)
-        else
-          content[#content + 1] = value.content
-        end
-      else
-        content[#content + 1] = value.content
-      end
+      content[#content + 1] = t[i].content
     end
     return content
   end
@@ -25870,7 +25794,7 @@ function M.reader.new(writer, options)
   local function find_full_link_next_closer(t, latest_index)
     for i = latest_index, #t do
       local value = t[i]
-      if not value.is_opening and
+      if value.is_closing and
          value.element == "link" and
          not value.removed then
         return i
@@ -25952,41 +25876,19 @@ function M.reader.new(writer, options)
 %    \end{macrocode}
 % \begin{markdown}
 %
-% Extract the attributes from an `attribute_list` where the attributes are still separated with spacing.
+% Join the attributes from the link reference definition `reference_attributes` with the link's own
+% attributes `own_attributes`.
 %
 % \end{markdown}
 %  \begin{macrocode}
-  local function extract_attributes(attribute_list)
-    local attributes = {}
-
-    if attribute_list == nil then
-      return attributes
-    end
-
-    for i = 2, #attribute_list, 2 do
-      attributes[#attributes + 1] = attribute_list[i]
-    end
-    return attributes
-  end
-
-%    \end{macrocode}
-% \begin{markdown}
-%
-% Join the attributes from the link reference definition `attribute_list` with the attributes of
-% a closing delimiter at index `index` in the delimiter table `t`.
-%
-% \end{markdown}
-%  \begin{macrocode}
-  local function join_attributes(attribute_list, t, closing_index)
-    local joined_attributes = attribute_list
+  local function join_attributes(reference_attributes, own_attributes)
+    local joined_attributes = reference_attributes
     if joined_attributes == nil then
       joined_attributes = {}
     end
 
-    if t[closing_index].content.attribute_content ~= nil then
-      local closing_attributes = extract_attributes(t[closing_index].content.attribute_content.content)
-
-      for _, attribute in ipairs(closing_attributes) do
+    if own_attributes ~= nil then
+      for _, attribute in ipairs(own_attributes) do
         table.insert(joined_attributes, attribute)
       end
     end
@@ -26008,25 +25910,17 @@ function M.reader.new(writer, options)
   local function render_link_or_image(t, opening_index, closing_index, content_end_index)
     local link_r = t[opening_index].reference
 
-    local url = ""
-    if (link_r.url ~= nil) then
-      url = link_r.url
-    end
-
-    local title = ""
-    if (link_r.title ~= nil) then
-      title = link_r.title
-    end
-
+    local url = link_r.url or ""
+    local title = link_r.title or ""
     local attributes = link_r.attributes
-
-    process_emphasis(t, opening_index, content_end_index)
-
-    local mapped = collect_emphasis_content(t, opening_index + 1, content_end_index - 1)
 
     if attributes == nil or not next(attributes) then
       attributes = nil
     end
+
+    process_emphasis(t, opening_index, content_end_index)
+
+    local mapped = collect_emphasis_content(t, opening_index + 1, content_end_index - 1)
 
     local rendered = {}
     if (t[opening_index].element == "link") then
@@ -26039,16 +25933,58 @@ function M.reader.new(writer, options)
 
     t[opening_index].rendered = rendered
     delete_parsed_content_in_range(t, opening_index + 1, closing_index)
-    empty_content_in_range(t, opening_index + 1, closing_index - 1)
+    empty_content_in_range(t, opening_index, closing_index)
     disable_previous_link_openers(t, opening_index)
     disable_range(t, opening_index, closing_index)
+  end
 
-    if (t[closing_index].is_direct and t[opening_index].link_type ~= "inline") then
-      t[closing_index].content = resolve_inline_link_closer(t, closing_index, false)
-    else
-      t[closing_index].content = ''
+%    \end{macrocode}
+% \begin{markdown}
+%
+% Match the link destination of an inline link at index `closing_index` in table `t`
+% when `match_reference` is true. Additionally match attributes when the option
+% \Opt{linkAttributes} is enabled.
+%
+% \end{markdown}
+%  \begin{macrocode}
+  local function resolve_inline_following_content(t, closing_index, match_reference, match_attributes)
+    local content = ""
+    for i = closing_index + 1, #t do
+      content = content .. t[i].content
+    end
+
+  local matching_content = parsers.succeed
+
+  if match_reference then
+    matching_content = matching_content * parsers.inline_direct_ref
+  end
+
+  if match_attributes then
+    matching_content = matching_content * Cg(Ct(parsers.attributes^-1), "attributes")
+  end
+
+  local matched = lpeg.match(Ct(matching_content * Cg(Cp(), "end_position")), content)
+
+  local matched_count = matched.end_position - 1
+  for i = closing_index + 1, #t do
+    t[i].is_active = false
+    local current = t[i].content
+    t[i].content = ''
+
+    local chars_left = matched_count
+    matched_count = matched_count - #current
+
+    if matched_count <= 0 then
+      local s = current:sub(chars_left + 1)
+      t[i].content = s
+      break
     end
   end
+
+  return { url = matched.url, 
+           title = matched.title, 
+           attributes = matched.attributes }
+end
 
 %    \end{macrocode}
 % \begin{markdown}
@@ -26060,26 +25996,9 @@ function M.reader.new(writer, options)
 %  \begin{macrocode}
   -- compared to other link types, here no reference definition is looked up
   local function resolve_inline_link(t, opening_index, closing_index)
-    local parentheses_info = t[closing_index].content.inline_content
+    local inline_content = resolve_inline_following_content(t, closing_index, true, t.match_attributes)
 
-    local all_attributes = {}
-    if t[closing_index].content.attribute_content ~= nil then
-       all_attributes = extract_attributes(t[closing_index].content.attribute_content.content)
-    end
-
-    local url = ""
-    if (parentheses_info.url_content ~= nil) then
-      url = parentheses_info.url_content.url
-    end
-
-    local title = ""
-    if (parentheses_info.title_content ~= nil) then
-      title = parentheses_info.title_content.title
-    end
-
-    t[opening_index].reference = { url = url,
-                                   title = title,
-                                   attributes = all_attributes }
+    t[opening_index].reference = inline_content
     
     render_link_or_image(t, opening_index, closing_index, closing_index)
   end
@@ -26097,8 +26016,10 @@ function M.reader.new(writer, options)
     local content_rope = util.rope_to_string(content)
     local r = self.lookup_reference(content_rope)
 
+    local inline_content = resolve_inline_following_content(t, closing_index, false, t.match_attributes)
+
     if r then 
-      local all_attributes = join_attributes(r.attributes, t, closing_index)
+      local all_attributes = join_attributes(r.attributes, inline_content.attributes)
 
       r.attributes = all_attributes
       t[opening_index].reference = r
@@ -26125,8 +26046,10 @@ function M.reader.new(writer, options)
 
     local r = self.lookup_reference(next_link_content_rope)
 
+    local inline_content = resolve_inline_following_content(t, full_index_closer, false, t.match_attributes)
+
     if r then 
-      local all_attributes = join_attributes(r.attributes, t, full_index_closer)
+      local all_attributes = join_attributes(r.attributes, inline_content.attributes)
 
       r.attributes = all_attributes
       t[opening_index].reference = r
@@ -26149,8 +26072,10 @@ function M.reader.new(writer, options)
 
     local r = self.lookup_reference(content_rope)
 
+    local inline_content = resolve_inline_following_content(t, closing_index, false, t.match_attributes)
+
     if r then       
-      local all_attributes = join_attributes(r.attributes, t, closing_index)
+      local all_attributes = join_attributes(r.attributes, inline_content.attributes)
 
       r.attributes = all_attributes
       t[opening_index].reference = r
@@ -26171,53 +26096,49 @@ function M.reader.new(writer, options)
 %  \begin{macrocode}
   function process_links_and_emphasis(delimiter_table)
     local t = delimiter_table[1]
+    t.match_attributes = delimiter_table.match_attributes
     for _,value in ipairs(t) do
       value.is_active = true
     end
-    local current_position = 1
 
     -- iterate over delimiters, rendering links and images
-    while current_position <= #t do
-      local value = t[current_position]
+    for i = 1, #t do
+      local value = t[i]
 
-      if not value.is_opening and value.type == "delimiter" and (value.element == "link" or value.element == "image") then
-
-        local opener_position = find_link_opener(t, 1, current_position - 2)
-
-        if (opener_position ~= nil) then
-          local opening_delimiter = t[opener_position]
-          t[opener_position].removed = true
-
-          local link_type = opening_delimiter.link_type
-          
-          if (link_type == "inline") then
-            resolve_inline_link(t, opener_position, current_position)
-          end
-          if (link_type == "shortcut") then
-            resolve_shortcut_link(t, opener_position, current_position)
-          end
-          if (link_type == "full") then
-            resolve_full_link(t, opener_position, current_position)
-          end
-          if (link_type == "collapsed") then
-            resolve_collapsed_link(t, opener_position, current_position)
-          end
-        end
-
-        if not t[current_position].removed and t[current_position].is_direct then
-          t[current_position].content = resolve_inline_link_closer(t, current_position, true)
-        end
+      if not value.is_closing or 
+        value.type ~= "delimiter" or 
+        not (value.element == "link" or value.element == "image") then
+        goto continue
       end
-      current_position = current_position + 2
+
+      local opener_position = find_link_opener(t, 1, i - 2)
+      if (opener_position == nil) then
+        goto continue
+      end
+
+      local opening_delimiter = t[opener_position]
+      opening_delimiter.removed = true
+
+      local link_type = opening_delimiter.link_type
+      
+      if (link_type == "inline") then
+        resolve_inline_link(t, opener_position, i)
+      end
+      if (link_type == "shortcut") then
+        resolve_shortcut_link(t, opener_position, i)
+      end
+      if (link_type == "full") then
+        resolve_full_link(t, opener_position, i)
+      end
+      if (link_type == "collapsed") then
+        resolve_collapsed_link(t, opener_position, i)
+      end
+
+      ::continue::
     end
 
-
     process_emphasis(t, 1, #t)
-
-
     local final_result = collect_emphasis_content(t, 1, #t)
-
-
     return final_result
   end
 
@@ -28407,53 +28328,10 @@ M.extensions.link_attributes = function()
 % \end{markdown}
 %  \begin{macrocode}
 
-      local attributes  = Cg(parsers.lbrace, "opening")
-                        * Cg(Ct(C(parsers.optionalspace)
-                        * parsers.attribute
-                        * (C(parsers.spacechar^1)
-                          * parsers.attribute)^0
-                        * C(parsers.optionalspace)), "content")
-                        * Cg(parsers.rbrace, "ending")
-
-      local inline_link = parsers.link_text
-                        * parsers.inline_direct_ref
-                        * (Ct(attributes))^-1
-
-      local simple_link = parsers.link_text
-                        * (Ct(attributes))^-1
-
-      local any_link  = inline_link
-                      + simple_link
-
-      local link_image_closing  = Ct( Cg(Cc("delimiter"), "type")
-                                    * Cg(Cc("link"), "element")
-                                    * Cg(Cc(false), "is_opening")
-                                    * ( Cg(Cc(true), "is_direct")
-                                      * Cg(Ct(C(parsers.rbracket)
-                                              * Cg(Ct(parsers.inline_direct_ref), "inline_content")
-                                              * Cg(Ct(attributes)^-1, "attribute_content")), "content")
-                                      + Cg(Cc(false), "is_direct")
-                                      * Cg(Ct(C(parsers.rbracket) * Cg(Ct(attributes)^-1, "attribute_content")), "content")))
-
-      local link_image_open_or_close  = parsers.link_image_opening
-                                      + link_image_closing
-
-      local link_and_emph_content = Ct( Cg(Cc("content"), "type")
-                                * Cg(Cs((
-                                        parsers.link_emph_precedence 
-                                        + parsers.backslash^-1 * parsers.any
-                                        - parsers.blankline^2
-                                        - link_image_open_or_close
-                                        - parsers.emph_open_or_close)^0), "content"))
-
-      local link_and_emph_table = Ct((parsers.link_image_opening + parsers.emph_open)
-                                      * ((link_and_emph_content)
-                                        * (link_image_open_or_close + parsers.emph_open_or_close))^1)
-
-      local MaybeLinkWithAttributesAndEmph  = Ct(link_and_emph_table)
+      local MaybeLinkWithAttributesAndEmph  = Ct(parsers.link_and_emph_table * Cg(Cc(true), "match_attributes"))
                                               / defer_link_and_emphasis_processing
 
-      local LinkWithAttributesAndEmph       = Ct(link_and_emph_table)
+      local LinkWithAttributesAndEmph       = Ct(parsers.link_and_emph_table * Cg(Cc(true), "match_attributes"))
                                             / process_links_and_emphasis
 
       self.update_rule("MaybeLinkAndEmph", MaybeLinkWithAttributesAndEmph)

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -1720,9 +1720,8 @@ local walkable_syntax = {
     "Str",
     "Space",
     "Endline",
-    "Emph",
-    "MaybeLinkOrImage",
-    "LinkOrImage",
+    "MaybeLinkAndEmph",
+    "LinkAndEmph",
     "Code",
     "AutoLinkUrl",
     "AutoLinkEmail",
@@ -4886,10 +4885,8 @@ be produced and contain the following text:
         "Str",
         "Space",
         "Endline",
-        "Emph",
-        "StrikeThrough (user-defined \"./strike-through.lua\" syntax extension)",
-        "MaybeLinkOrImage",
-        "LinkOrImage",
+        "MaybeLinkAndEmph",
+        "LinkAndEmph",
         "Code",
         "AutoLinkUrl",
         "AutoLinkEmail",
@@ -24626,6 +24623,11 @@ function M.reader.new(writer, options)
                      function()
                        return parsers.inlines_nbsp
                      end, false)
+
+  self.create_parser("parse_inlines_no_link_or_image",
+                    function()
+                      return parsers.inlines_no_link_or_image
+                    end, false)
 %    \end{macrocode}
 % \par
 % \begin{markdown}
@@ -25256,6 +25258,13 @@ function M.reader.new(writer, options)
 % \end{markdown}
 %  \begin{macrocode}
 
+  local function parse_content_part(content_part)
+    local rope = util.rope_to_string(content_part)
+    local parsed = self.parser_functions.parse_inlines_no_link_or_image(rope)
+    parsed.indent_info = nil
+    return parsed
+  end
+
 %  \end{macrocode}
 % \begin{markdown}
 %
@@ -25265,17 +25274,33 @@ function M.reader.new(writer, options)
 %  \begin{macrocode}
   local function collect_emphasis_content(t, opening_index, closing_index)
     local content = {}
+
+    local content_part = {}
     for i = opening_index, closing_index do
       local value = t[i]
-      if value.is_active then
-        if value.type == "delimiter_run" then
-          content[#content + 1] = writer.escape(string.rep(value.character, value.current_count))
-        else
-          content[#content + 1] = value.content
-          value.content = ''
+
+      if value.rendered ~= nil then
+        content[#content + 1] = parse_content_part(content_part)
+        content_part = {}
+        content[#content + 1] = value.rendered
+        value.rendered = nil
+      else
+        if value.is_active then
+          if value.type == "delimiter" and value.element == "emphasis" then
+            content[#content + 1] = parse_content_part(content_part)
+            content_part = {}
+            content[#content + 1] = writer.escape(string.rep(value.character, value.current_count))
+          else
+            content_part[#content_part + 1] = value.content
+            value.content = ''
+          end
+          value.is_active = false
         end
-        value.is_active = false
       end
+    end
+
+    if next(content_part) ~= nil then
+      content[#content + 1] = parse_content_part(content_part)
     end
 
     return content
@@ -25292,7 +25317,7 @@ function M.reader.new(writer, options)
   local function fill_emph(t, opening_index, closing_index)
     local content = collect_emphasis_content(t, opening_index + 1, closing_index - 1)
     t[opening_index + 1].is_active = true
-    t[opening_index + 1].content = writer.emphasis(content)
+    t[opening_index + 1].rendered = writer.emphasis(content)
   end
 
 %  \end{macrocode}
@@ -25306,7 +25331,7 @@ function M.reader.new(writer, options)
   local function fill_strong(t, opening_index, closing_index)
     local content = collect_emphasis_content(t, opening_index + 1, closing_index - 1)
     t[opening_index + 1].is_active = true
-    t[opening_index + 1].content = writer.strong(content)
+    t[opening_index + 1].rendered = writer.strong(content)
   end
 
 %  \end{macrocode}
@@ -25356,8 +25381,7 @@ function M.reader.new(writer, options)
 %  \begin{macrocode}
   local function process_emphasis(t)
     for _,value in ipairs(t) do
-      value.is_active = true
-      if value.type == "delimiter_run" then
+      if value.type == "delimiter" and value.element == "emphasis" then
           local delimiter_length = string.len(value.content)
           value.character = string.sub(value.content, 1, 1)
           value.current_count = delimiter_length
@@ -25387,35 +25411,40 @@ function M.reader.new(writer, options)
 
     while current_position <= #t do
       local value = t[current_position]
-      local character = value.character
-      local is_opening = value.is_opening
-      local is_closing = value.is_closing
-      local closing_length_modulo_three = value.original_count % 3
 
-      local current_openers_bottom = openers_bottom[character][is_opening][closing_length_modulo_three + 1]
+      if value.type == "delimiter" and value.is_active and value.element == "emphasis" then
+        local character = value.character
+        local is_opening = value.is_opening
+        local is_closing = value.is_closing
+        local closing_length_modulo_three = value.original_count % 3
 
-      if is_closing and (value.current_count > 0) then
-        local opener_position = find_opener(t, current_openers_bottom, current_position - 2, character, value)
+        local current_openers_bottom = openers_bottom[character][is_opening][closing_length_modulo_three + 1]
 
-        if (opener_position ~= nil) then
+        if is_closing and (value.current_count > 0) then
+          local opener_position = find_opener(t, current_openers_bottom, current_position - 2, character, value)
 
-          local opening_delimiter = t[opener_position]
+          if (opener_position ~= nil) then
 
-          local current_opening_count = opening_delimiter.current_count
-          local current_closing_count = t[current_position].current_count
+            local opening_delimiter = t[opener_position]
 
-          if (current_opening_count >= 2) and (current_closing_count >= 2) then
-            opening_delimiter.current_count = current_opening_count - 2
-            t[current_position].current_count = current_closing_count - 2
-            fill_strong(t, opener_position, current_position)
+            local current_opening_count = opening_delimiter.current_count
+            local current_closing_count = t[current_position].current_count
+
+            if (current_opening_count >= 2) and (current_closing_count >= 2) then
+              opening_delimiter.current_count = current_opening_count - 2
+              t[current_position].current_count = current_closing_count - 2
+              fill_strong(t, opener_position, current_position)
+            else
+              opening_delimiter.current_count = current_opening_count - 1
+              t[current_position].current_count = current_closing_count - 1
+              fill_emph(t, opener_position, current_position)
+            end
+
           else
-            opening_delimiter.current_count = current_opening_count - 1
-            t[current_position].current_count = current_closing_count - 1
-            fill_emph(t, opener_position, current_position)
+            openers_bottom[character][is_opening][closing_length_modulo_three + 1] = current_position
+            current_position = current_position + 2
           end
-
         else
-          openers_bottom[character][is_opening][closing_length_modulo_three + 1] = current_position
           current_position = current_position + 2
         end
       else
@@ -25520,7 +25549,8 @@ function M.reader.new(writer, options)
   parsers.right_flanking_delimiter_run = function(character)
     return  parsers.unicode_preceding_punctuation
           * parsers.delimiter_run(character)
-          * (parsers.unicode_following_punctuation + parsers.unicode_following_whitespace)
+          * (parsers.unicode_following_punctuation + parsers.unicode_following_whitespace
+            + parsers.eof)
           + (B(parsers.any) 
             * -(parsers.unicode_preceding_punctuation + parsers.unicode_preceding_whitespace))
           * parsers.delimiter_run(character)
@@ -25539,17 +25569,20 @@ function M.reader.new(writer, options)
                     * parsers.right_flanking_delimiter_run(parsers.underscore)
 
   parsers.emph_capturing_open_and_close = #parsers.emph_start * #parsers.emph_end
-                                        * Ct( Cg(Cc("delimiter_run"), "type")
+                                        * Ct( Cg(Cc("delimiter"), "type")
+                                            * Cg(Cc("emphasis"), "element")
                                             * Cg(C(parsers.emph_start), "content")
                                             * Cg(Cc(true), "is_opening")
                                             * Cg(Cc(true), "is_closing"))
 
-  parsers.emph_capturing_open = Ct( Cg(Cc("delimiter_run"), "type")
+  parsers.emph_capturing_open = Ct( Cg(Cc("delimiter"), "type")
+                                  * Cg(Cc("emphasis"), "element")
                                   * Cg(C(parsers.emph_start), "content")
                                   * Cg(Cc(true), "is_opening")
                                   * Cg(Cc(false), "is_closing"))
 
-  parsers.emph_capturing_close = Ct( Cg(Cc("delimiter_run"), "type")
+  parsers.emph_capturing_close = Ct( Cg(Cc("delimiter"), "type")  
+                                   * Cg(Cc("emphasis"), "element")
                                    * Cg(C(parsers.emph_end), "content")
                                    * Cg(Cc(false), "is_opening")
                                    * Cg(Cc(true), "is_closing"))
@@ -25701,7 +25734,7 @@ function M.reader.new(writer, options)
                         + #parsers.link_text
                         * Cg(Cc("link_text"), "link_type")
 
-  parsers.link_image_opening  = Ct( Cg(Cc("delim"), "type")
+  parsers.link_image_opening  = Ct( Cg(Cc("delimiter"), "type")
                                   * Cg(Cc(true), "is_opening")
                                   * ( Cg(Cc("image"), "element")
                                     * parsers.image_opening
@@ -25710,7 +25743,8 @@ function M.reader.new(writer, options)
                                     * parsers.link_opening
                                     * Cg(parsers.lbracket, "content")))
 
-  parsers.link_image_closing  = Ct( Cg(Cc("delim"), "type")
+  parsers.link_image_closing  = Ct( Cg(Cc("delimiter"), "type")
+                                  * Cg(Cc("link"), "element")
                                   * Cg(Cc(false), "is_opening")
                                   * ( Cg(Cc(true), "is_direct")
                                     * Cg(Ct(C(parsers.rbracket) * Cg(Ct(parsers.inline_direct_ref), "inline_content")), "content")
@@ -25720,13 +25754,20 @@ function M.reader.new(writer, options)
   parsers.link_image_open_or_close  = parsers.link_image_opening
                                     + parsers.link_image_closing
 
-  parsers.link_image_content  = Ct( Cg(Cc("content"), "type")
-                                  * Cg(C(((parsers.backslash^-1 / "" * parsers.any - parsers.link_image_open_or_close))^0), "content"))
+  parsers.link_emph_precedence  = parsers.inticks
+                                + parsers.autolink
 
-  parsers.link_array = C((parsers.exclamation^-1 * parsers.any_link)^1)
+  parsers.link_and_emph_content = Ct( Cg(Cc("content"), "type")
+                                  * Cg(Cs((
+                                          parsers.link_emph_precedence 
+                                          + parsers.backslash^-1 * parsers.any
+                                          - parsers.blankline^2
+                                          - parsers.link_image_open_or_close 
+                                          - parsers.emph_open_or_close)^0), "content"))
 
-  parsers.link_group = Ct( parsers.link_image_opening
-                        * (parsers.link_image_content * parsers.link_image_open_or_close)^0)
+  parsers.link_and_emph_table = Ct((parsers.link_image_opening + parsers.emph_open)
+                                  * ((parsers.link_and_emph_content)
+                                     * (parsers.link_image_open_or_close + parsers.emph_open_or_close))^1)
 
 %    \end{macrocode}
 % \begin{markdown}
@@ -25739,7 +25780,7 @@ function M.reader.new(writer, options)
 %  \begin{macrocode}
   local function resolve_inline_link_closer(t, index, include_bracket)
     local value = t[index]
-    if value.type == "delim" then
+    if value.type == "delimiter" and (value.element == "link" or value.element == "image") then
       local inline_content = value.content.inline_content
       local attribute_content = value.content.attribute_content
 
@@ -25791,7 +25832,7 @@ function M.reader.new(writer, options)
     local content = {}
     for i = opening_index, closing_index do
       local value = t[i]
-      if value.type == "delim" then
+      if value.type == "delimiter" and (value.element == "link" or value.element == "image") then
         if value.is_direct then
           content[#content + 1] = resolve_inline_link_closer(t, i, true)
         else
@@ -25863,7 +25904,7 @@ function M.reader.new(writer, options)
     for i = index, 1, -1 do
       local value = t[i]
       if value.is_active and
-         value.type == "delim" and
+         value.type == "delimiter" and
          value.is_opening and
          value.element == "link" then
         value.is_active = false
@@ -25900,6 +25941,19 @@ function M.reader.new(writer, options)
   local function delete_parsed_content_in_range(t, opening_index, closing_index)
     for i = opening_index, closing_index do
       t[i].rendered = nil
+    end
+  end
+
+%    \end{macrocode}
+% \begin{markdown}
+%
+% Clear the parsed content between the `opening_index` and `closing_index` in the delimiter table `t`.
+%
+% \end{markdown}
+%  \begin{macrocode}
+  local function empty_content_in_range(t, opening_index, closing_index)
+    for i = opening_index, closing_index do
+      t[i].content = ''
     end
   end
 
@@ -26153,7 +26207,7 @@ function M.reader.new(writer, options)
 %    \end{macrocode}
 % \begin{markdown}
 %
-% Parse an array of links `link_array` to an array of delimiters and content with the 'link_group` pattern.
+% Parse a table of link and emphasis delimiters `delimiter_table`.
 % Iterate over the delimiters in the delimiter table `t` in two passes. First, the delimiters either 
 % marked as links (or images) with the `is_link` property, additionally assigned a closing delimiter. 
 % Secondly, the content of the resolved links is parsed, with respective macros produced. 
@@ -26162,26 +26216,22 @@ function M.reader.new(writer, options)
 %
 % \end{markdown}
 %  \begin{macrocode}
-  function process_links_and_images(link_array, link_group)
-
-    -- generate a delimiter array from a array of potential links
-    local t = lpeg.match(link_group, link_array[1])
-
+  function process_links_and_emphasis(delimiter_table)
+    local t = delimiter_table[1]
     for _,value in ipairs(t) do
       value.is_active = true
-      if (value.is_opening) then
+      if (value.is_opening and value.type == "delimiter" and (value.element == "link" or value.element == "image")) then
         value.is_link = false
         value.end_position = 0
       end
     end
-
     local current_position = 1
 
     -- iterate over delimiters, marking links
     while current_position <= #t do
       local value = t[current_position]
 
-      if not value.is_opening then
+      if not value.is_opening and value.type == "delimiter" and (value.element == "link" or value.element == "image") then
         local opener_position, non_active_opener_position = find_opener(t, 1, current_position - 2)
         local end_position = current_position
 
@@ -26227,31 +26277,47 @@ function M.reader.new(writer, options)
     end
 
     current_position = 1
-
     -- iterate over found links, parsing content
     while current_position <= #t do
       local delimiter = t[current_position]
 
-      if delimiter.is_opening then
+      if delimiter.is_opening and delimiter.type == "delimiter" and delimiter.is_link then
         local end_position = delimiter.end_position
-
-        if (delimiter.is_link) then
-          render_link_or_image(t, current_position, end_position)
-        else
-          render_link_or_image_fallback(t, current_position, end_position)
-        end
+        render_link_or_image(t, current_position, end_position)
 
         current_position = end_position
       end
       current_position = current_position + 2
     end
+    current_position = 1
 
-    return collect_link_parsed_content(t, 1, #t)
+    -- iterate over content, restoring activeness
+    while current_position <= #t do
+      local item = t[current_position]
+      item.is_active = true
+
+      if item.type == "delimiter" and (item.element == "link" or item.element == "image") then
+        if item.is_opening and item.is_link then
+
+          local end_position = item.end_position
+          empty_content_in_range(t, current_position, end_position) -- remove self content too
+
+          current_position = end_position
+        end
+        if item.is_direct then
+          item.content = resolve_inline_link_closer(t, current_position, true)
+        end
+      end
+      current_position = current_position + 1
+    end
+
+    local emph_t = process_emphasis(t)
+    return emph_t
   end
 
-  function defer_link_and_image_processing(links, link_group)
+  function defer_link_and_emphasis_processing(delimiter_table)
     return writer.defer_call(function()
-      return process_links_and_images(links, link_group)
+      return process_links_and_emphasis(delimiter_table)
     end)
   end
 
@@ -26312,6 +26378,10 @@ function M.reader.new(writer, options)
                      + parsers.headerstart
                      + parsers.html_interrupting
 
+  parsers.EndlineExceptionsInside
+                     = parsers.EndlineExceptions
+                     - parsers.eof
+
   parsers.Endline   = parsers.newline
                     * (parsers.check_minimal_indent 
                       * -V("EndlineExceptions") 
@@ -26325,15 +26395,18 @@ function M.reader.new(writer, options)
   parsers.OptionalIndent
                      = parsers.spacechar^1 / writer.space
 
-  parsers.Space      = parsers.spacechar^2 * parsers.Endline / writer.hard_line_break
-                     + parsers.spacechar^1 * parsers.Endline^-1 * parsers.eof / ""
+  parsers.Space      = parsers.spacechar^2 * parsers.Endline
+                                           / (options.hardLineBreaks
+                                              and writer.hard_line_break
+                                               or writer.space)
+                     + parsers.spacechar^1 * parsers.Endline^-1 * parsers.eof / self.expandtabs
                      + parsers.spacechar^1 * parsers.Endline
                                            * parsers.optionalspace
                                            / (options.hardLineBreaks
                                               and writer.hard_line_break
                                                or writer.space)
-                     + parsers.spacechar^1 * parsers.optionalspace
-                                           / writer.space
+                     + parsers.spacechar^1 * -parsers.newline / self.expandtabs
+                     + parsers.spacechar^1 / ""
 
   parsers.NonbreakingEndline
                     = parsers.newline
@@ -26347,7 +26420,10 @@ function M.reader.new(writer, options)
                                                or writer.nbsp)
 
   parsers.NonbreakingSpace
-                  = parsers.spacechar^2 * parsers.Endline / writer.hard_line_break
+                  = parsers.spacechar^2 * parsers.Endline
+                                        / (options.hardLineBreaks
+                                              and writer.hard_line_break
+                                               or writer.nbsp)
                   + parsers.spacechar^1 * parsers.Endline^-1 * parsers.eof / ""
                   + parsers.spacechar^1 * parsers.Endline
                                         * parsers.optionalspace
@@ -26403,11 +26479,11 @@ end
                       = parsers.auto_link_relative_reference
                       / self.auto_link_url
 
-  parsers.MaybeLinkOrImage = Ct(parsers.link_array) * Cc(parsers.link_group)
-                           / defer_link_and_image_processing
+  parsers.MaybeLinkAndEmph = Ct(parsers.link_and_emph_table)
+                           / defer_link_and_emphasis_processing
 
-  parsers.LinkOrImage     = Ct(parsers.link_array) * Cc(parsers.link_group)
-                          / process_links_and_images
+  parsers.LinkAndEmph     = Ct(parsers.link_and_emph_table)
+                          / process_links_and_emphasis
 
   parsers.EscapedChar   = parsers.backslash * C(parsers.escapable) / writer.string
 
@@ -26754,9 +26830,8 @@ end
         Space                 = parsers.Space,
         OptionalIndent        = parsers.OptionalIndent,
         Endline               = parsers.Endline,
-        Emph                  = parsers.Emph,
-        MaybeLinkOrImage      = parsers.MaybeLinkOrImage,
-        LinkOrImage           = parsers.fail,
+        MaybeLinkAndEmph      = parsers.MaybeLinkAndEmph,
+        LinkAndEmph           = parsers.fail,
         Code                  = parsers.Code,
         AutoLinkUrl           = parsers.AutoLinkUrl,
         AutoLinkEmail         = parsers.AutoLinkEmail,
@@ -27055,10 +27130,16 @@ end
     inlines_nbsp_t.Space = parsers.NonbreakingSpace
     parsers.inlines_nbsp = Ct(inlines_nbsp_t)
 
-    local inlines_full_link_and_image = util.table_copy(inlines_t)
-    inlines_full_link_and_image.MaybeLinkOrImage = parsers.fail
-    inlines_full_link_and_image.LinkOrImage = parsers.LinkOrImage
-    parsers.inlines_full_link_and_image = Ct(inlines_full_link_and_image)
+    local inlines_full_link_and_image_t = util.table_copy(inlines_t)
+    inlines_full_link_and_image_t.MaybeLinkAndEmph = parsers.fail
+    inlines_full_link_and_image_t.LinkAndEmph = parsers.LinkAndEmph
+    parsers.inlines_full_link_and_image = Ct(inlines_full_link_and_image_t)
+
+    local inlines_no_link_or_image_t = util.table_copy(inlines_t)
+    inlines_no_link_or_image_t.MaybeLinkAndEmph = parsers.fail
+    inlines_no_link_or_image_t.LinkAndEmph = parsers.fail
+    inlines_no_link_or_image_t.EndlineExceptions = parsers.EndlineExceptionsInside
+    parsers.inlines_no_link_or_image = Ct(inlines_no_link_or_image_t)
 %    \end{macrocode}
 % \par
 % \begin{markdown}
@@ -28442,31 +28523,39 @@ M.extensions.link_attributes = function()
       local any_link  = inline_link
                       + simple_link
 
-      local link_image_closing  = Ct( Cg(Cc("delim"), "type")
-                                      * Cg(Cc(false), "is_opening")
-                                      * ( Cg(Cc(true), "is_direct")
-                                        * Cg(Ct(C(parsers.rbracket) 
-                                               * Cg(Ct(parsers.inline_direct_ref), "inline_content") 
-                                               * Cg(Ct(attributes)^-1, "attribute_content")), "content")
-                                        + Cg(Cc(false), "is_direct")
-                                        * Cg(Ct(C(parsers.rbracket) * Cg(Ct(attributes)^-1, "attribute_content")), "content")))
+      local link_image_closing  = Ct( Cg(Cc("delimiter"), "type")
+                                    * Cg(Cc("link"), "element")
+                                    * Cg(Cc(false), "is_opening")
+                                    * ( Cg(Cc(true), "is_direct")
+                                      * Cg(Ct(C(parsers.rbracket)
+                                              * Cg(Ct(parsers.inline_direct_ref), "inline_content")
+                                              * Cg(Ct(attributes)^-1, "attribute_content")), "content")
+                                      + Cg(Cc(false), "is_direct")
+                                      * Cg(Ct(C(parsers.rbracket) * Cg(Ct(attributes)^-1, "attribute_content")), "content")))
 
       local link_image_open_or_close  = parsers.link_image_opening
-                                        + link_image_closing
+                                      + link_image_closing
 
-      local link_group  = Ct( parsers.link_image_opening
-                          * (parsers.link_image_content * link_image_open_or_close)^0)
+      local link_and_emph_content = Ct( Cg(Cc("content"), "type")
+                                * Cg(Cs((
+                                        parsers.link_emph_precedence 
+                                        + parsers.backslash^-1 * parsers.any
+                                        - parsers.blankline^2
+                                        - link_image_open_or_close
+                                        - parsers.emph_open_or_close)^0), "content"))
 
-      local link_array = C((parsers.exclamation^-1 * any_link)^1)
+      local link_and_emph_table = Ct((parsers.link_image_opening + parsers.emph_open)
+                                      * ((link_and_emph_content)
+                                        * (link_image_open_or_close + parsers.emph_open_or_close))^1)
 
-      local MaybeLinkOrImageWithAttributes  = Ct(link_array) * Cc(link_group)
-                                              / defer_link_and_image_processing
+      local MaybeLinkWithAttributesAndEmph  = Ct(link_and_emph_table)
+                                              / defer_link_and_emphasis_processing
 
-      local LinkOrImageWithAttributes       = Ct(link_array) * Cc(link_group)
-                                            / process_links_and_images
+      local LinkWithAttributesAndEmph       = Ct(link_and_emph_table)
+                                            / process_links_and_emphasis
 
-      self.update_rule("MaybeLinkOrImage", MaybeLinkOrImageWithAttributes)
-      self.update_rule("LinkOrImage", LinkOrImageWithAttributes)
+      self.update_rule("MaybeLinkAndEmph", MaybeLinkWithAttributesAndEmph)
+      self.update_rule("LinkAndEmph", LinkWithAttributesAndEmph)
 
 %    \end{macrocode}
 % \begin{markdown}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -25548,17 +25548,23 @@ function M.reader.new(writer, options)
           * parsers.delimiter_run(character)
   end
 
-  parsers.emph_start = parsers.left_flanking_delimiter_run(parsers.asterisk)
-                     + (-#parsers.right_flanking_delimiter_run(parsers.underscore)
-                        + (parsers.unicode_preceding_punctuation 
-                          * #parsers.right_flanking_delimiter_run(parsers.underscore)))
-                     * parsers.left_flanking_delimiter_run(parsers.underscore)
+  if options.underscores then
+    parsers.emph_start = parsers.left_flanking_delimiter_run(parsers.asterisk)
+                      + (-#parsers.right_flanking_delimiter_run(parsers.underscore)
+                          + (parsers.unicode_preceding_punctuation 
+                            * #parsers.right_flanking_delimiter_run(parsers.underscore)))
+                      * parsers.left_flanking_delimiter_run(parsers.underscore)
 
-  parsers.emph_end  = parsers.right_flanking_delimiter_run(parsers.asterisk)
-                    + (-#parsers.left_flanking_delimiter_run(parsers.underscore)
-                      + #(parsers.left_flanking_delimiter_run(parsers.underscore) 
-                         * parsers.unicode_following_punctuation))
-                    * parsers.right_flanking_delimiter_run(parsers.underscore)
+    parsers.emph_end  = parsers.right_flanking_delimiter_run(parsers.asterisk)
+                      + (-#parsers.left_flanking_delimiter_run(parsers.underscore)
+                        + #(parsers.left_flanking_delimiter_run(parsers.underscore) 
+                          * parsers.unicode_following_punctuation))
+                      * parsers.right_flanking_delimiter_run(parsers.underscore)
+  else
+    parsers.emph_start = parsers.left_flanking_delimiter_run(parsers.asterisk)
+
+    parsers.emph_end  = parsers.right_flanking_delimiter_run(parsers.asterisk)
+  end
 
   parsers.emph_capturing_open_and_close = #parsers.emph_start * #parsers.emph_end
                                         * Ct( Cg(Cc("delimiter"), "type")

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -24563,6 +24563,28 @@ end
 % \par
 % \begin{markdown}
 %
+%#### Parsers Used for HTML Entities
+%
+% \end{markdown}
+%  \begin{macrocode}
+local function repeat_between(pattern, min, max)
+  return -pattern^(max + 1) * pattern^min
+end
+
+parsers.hexentity = parsers.ampersand * parsers.hash * C(S("Xx"))
+                  * C(repeat_between(parsers.hexdigit, 1, 6)) * parsers.semicolon
+parsers.decentity = parsers.ampersand * parsers.hash
+                  * C(repeat_between(parsers.digit, 1, 7)) * parsers.semicolon
+parsers.tagentity = parsers.ampersand * C(parsers.alphanumeric^1)
+                  * parsers.semicolon
+
+parsers.html_entities = parsers.hexentity / entities.hex_entity_with_x_char
+                      + parsers.decentity / entities.dec_entity
+                      + parsers.tagentity / entities.char_entity
+%    \end{macrocode}
+% \par
+% \begin{markdown}
+%
 %#### Parsers Used for Markdown Lists
 %
 % \end{markdown}
@@ -24746,15 +24768,15 @@ parsers.url         = parsers.less * Cs((parsers.anyescaped
 
 -- quoted text:
 parsers.title_s     = parsers.squote
-                    * Cs((V("HtmlEntity") + (parsers.anyescaped - parsers.squote - parsers.blankline^2))^0)
+                    * Cs((parsers.html_entities + (parsers.anyescaped - parsers.squote - parsers.blankline^2))^0)
                     * parsers.squote
 
 parsers.title_d     = parsers.dquote
-                    * Cs((V("HtmlEntity") + (parsers.anyescaped - parsers.dquote - parsers.blankline^2))^0)
+                    * Cs((parsers.html_entities + (parsers.anyescaped - parsers.dquote - parsers.blankline^2))^0)
                     * parsers.dquote
 
 parsers.title_p     = parsers.lparent
-                    * Cs((V("HtmlEntity") + parsers.inparens + (parsers.anyescaped - parsers.rparent - parsers.blankline^2))^0)
+                    * Cs((parsers.html_entities + parsers.inparens + (parsers.anyescaped - parsers.rparent - parsers.blankline^2))^0)
                     * parsers.rparent
 
 parsers.title       = parsers.title_d + parsers.title_s + parsers.title_p
@@ -25129,24 +25151,6 @@ parsers.html_interrupting = parsers.html_incomplete_open_tag
                           - parsers.html_close_special_tag
                           - parsers.html_empty_special_tag
 
-%    \end{macrocode}
-% \par
-% \begin{markdown}
-%
-%#### Parsers Used for HTML Entities
-%
-% \end{markdown}
-%  \begin{macrocode}
-local function repeat_between(pattern, min, max)
-  return -pattern^(max + 1) * pattern^min
-end
-
-parsers.hexentity = parsers.ampersand * parsers.hash * C(S("Xx"))
-                  * C(repeat_between(parsers.hexdigit, 1, 6)) * parsers.semicolon
-parsers.decentity = parsers.ampersand * parsers.hash
-                  * C(repeat_between(parsers.digit, 1, 7)) * parsers.semicolon
-parsers.tagentity = parsers.ampersand * C(parsers.alphanumeric^1)
-                  * parsers.semicolon
 %    \end{macrocode}
 % \par
 % \begin{markdown}
@@ -26589,9 +26593,7 @@ end
                             + parsers.html_any_close_tag)
                           / writer.inline_html_tag
 
-  parsers.HtmlEntity    = parsers.hexentity / entities.hex_entity_with_x_char / writer.string
-                        + parsers.decentity / entities.dec_entity             / writer.string
-                        + parsers.tagentity / entities.char_entity            / writer.string
+  parsers.HtmlEntity    = parsers.html_entities / writer.string
 %    \end{macrocode}
 % \par
 % \begin{markdown}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -25356,7 +25356,7 @@ function M.reader.new(writer, options)
 %
 % \end{markdown}
 %  \begin{macrocode}
-  local function find_opener(t, bottom_index, latest_index, character, closing_delimiter)
+  local function find_emphasis_opener(t, bottom_index, latest_index, character, closing_delimiter)
     for i = latest_index, bottom_index, -2 do
       local value = t[i]
       if value.is_active and
@@ -25368,8 +25368,6 @@ function M.reader.new(writer, options)
         end
       end
     end
-
-    return nil
   end
 
 %  \end{macrocode}
@@ -25379,8 +25377,9 @@ function M.reader.new(writer, options)
 %
 % \end{markdown}
 %  \begin{macrocode}
-  local function process_emphasis(t)
-    for _,value in ipairs(t) do
+  local function process_emphasis(t, opening_index, closing_index)
+    for i = opening_index, closing_index do
+      local value = t[i]
       if value.type == "delimiter" and value.element == "emphasis" then
           local delimiter_length = string.len(value.content)
           value.character = string.sub(value.content, 1, 1)
@@ -25389,71 +25388,63 @@ function M.reader.new(writer, options)
       end
     end
 
-    local current_position = 1
     local openers_bottom = {
       ['*'] = { -- character
-        [true] = { -- is opening
-          1, 1, 1 -- lengths
-        },
-        [false] = {
-          1, 1, 1
-        }
+        [true] = {opening_index, opening_index, opening_index}, -- is opening
+        [false] = {opening_index, opening_index, opening_index}
       },
       ['_'] = {
-        [true] = {
-          1, 1, 1
-        },
-        [false] = {
-          1, 1, 1
-        }
+        [true] = {opening_index, opening_index, opening_index},
+        [false] = {opening_index, opening_index, opening_index}
       }
     }
 
-    while current_position <= #t do
+    local current_position = opening_index
+    local max_position = closing_index
+
+    while current_position <= max_position do
       local value = t[current_position]
-
-      if value.type == "delimiter" and value.is_active and value.element == "emphasis" then
-        local character = value.character
-        local is_opening = value.is_opening
-        local is_closing = value.is_closing
-        local closing_length_modulo_three = value.original_count % 3
-
-        local current_openers_bottom = openers_bottom[character][is_opening][closing_length_modulo_three + 1]
-
-        if is_closing and (value.current_count > 0) then
-          local opener_position = find_opener(t, current_openers_bottom, current_position - 2, character, value)
-
-          if (opener_position ~= nil) then
-
-            local opening_delimiter = t[opener_position]
-
-            local current_opening_count = opening_delimiter.current_count
-            local current_closing_count = t[current_position].current_count
-
-            if (current_opening_count >= 2) and (current_closing_count >= 2) then
-              opening_delimiter.current_count = current_opening_count - 2
-              t[current_position].current_count = current_closing_count - 2
-              fill_strong(t, opener_position, current_position)
-            else
-              opening_delimiter.current_count = current_opening_count - 1
-              t[current_position].current_count = current_closing_count - 1
-              fill_emph(t, opener_position, current_position)
-            end
-
-          else
-            openers_bottom[character][is_opening][closing_length_modulo_three + 1] = current_position
-            current_position = current_position + 2
-          end
-        else
-          current_position = current_position + 2
-        end
-      else
-        current_position = current_position + 2
+      
+      if value.type ~= "delimiter" or 
+        value.element ~= "emphasis" or 
+        not value.is_active or 
+        not value.is_closing or 
+        (value.current_count <= 0) then
+        current_position = current_position + 1
+        goto continue
       end
-    end
 
-    local final_result = collect_emphasis_content(t, 1, #t)
-    return final_result
+      local character = value.character
+      local is_opening = value.is_opening
+      local closing_length_modulo_three = value.original_count % 3
+
+      local current_openers_bottom = openers_bottom[character][is_opening][closing_length_modulo_three + 1]
+
+      local opener_position = find_emphasis_opener(t, current_openers_bottom, current_position - 2, character, value)
+
+      if (opener_position == nil) then
+        openers_bottom[character][is_opening][closing_length_modulo_three + 1] = current_position
+        current_position = current_position + 1
+        goto continue
+      end
+
+      local opening_delimiter = t[opener_position]
+
+      local current_opening_count = opening_delimiter.current_count
+      local current_closing_count = t[current_position].current_count
+
+      if (current_opening_count >= 2) and (current_closing_count >= 2) then
+        opening_delimiter.current_count = current_opening_count - 2
+        t[current_position].current_count = current_closing_count - 2
+        fill_strong(t, opener_position, current_position)
+      else
+        opening_delimiter.current_count = current_opening_count - 1
+        t[current_position].current_count = current_closing_count - 1
+        fill_emph(t, opener_position, current_position)
+      end
+      
+      ::continue::
+    end
   end
 
   local cont = lpeg.R("\128\191") -- continuation byte
@@ -25873,7 +25864,7 @@ function M.reader.new(writer, options)
 %
 % \end{markdown}
 %  \begin{macrocode}
-  local function find_opener(t, bottom_index, latest_index)
+  local function find_link_opener(t, bottom_index, latest_index)
     for i = latest_index, bottom_index, -2 do
       local value = t[i]
       if value.is_opening and 
@@ -26008,6 +25999,79 @@ function M.reader.new(writer, options)
 %    \end{macrocode}
 % \begin{markdown}
 %
+% Parse content between two delimiters in the delimiter table `t`. Produce the respective link and image 
+% macros and resolve potential dangling parentheses and attributes. 
+%
+% \end{markdown}
+%  \begin{macrocode}
+  local function render_link_or_image(t, opening_index, closing_index)
+    local link_r = t[opening_index].reference
+    local link_content_rope = t[opening_index].rope
+
+    local url = ""
+    if (link_r.url ~= nil) then
+      url = link_r.url
+    end
+
+    local title = ""
+    if (link_r.title ~= nil) then
+      title = link_r.title
+    end
+
+    local attributes = link_r.attributes
+
+    local mapped = self.parser_functions.parse_inlines_full_link_and_image(link_content_rope)
+
+    if attributes == nil or not next(attributes) then
+      attributes = nil
+    end
+
+    local rendered = {}
+    if (t[opening_index].element == "link") then
+      rendered = writer.link(mapped, url, title, attributes)
+    end
+
+    if (t[opening_index].element == "image") then
+      rendered = writer.image(mapped, url, title, attributes)
+    end
+
+    local mapped_parentheses = {}
+    if (t[closing_index].is_direct and t[opening_index].link_type ~= "inline") then
+      local resolved_closer = resolve_inline_link_closer(t, closing_index, false)
+      mapped_parentheses = self.parser_functions.parse_inlines_full_link_and_image(resolved_closer)
+    end
+
+    t[opening_index].rendered = { rendered, mapped_parentheses }
+    delete_parsed_content_in_range(t, opening_index + 1, closing_index)
+  end
+
+%    \end{macrocode}
+% \begin{markdown}
+%
+% Parse content between two delimiters in the delimiter table `t`. Enclose this content with literal brakcets and 
+% resolve potential dangling parentheses and attributes. 
+% In case of a image opening delimiter, an exclamation mark is also added before the brackets.
+%
+% \end{markdown}
+%  \begin{macrocode}
+  local function render_link_or_image_fallback(t, opening_index, closing_index)
+    local prefix = ""
+    if (t[opening_index].rendered) then
+      prefix = "!"
+    end
+
+    local content = collect_link_content(t, opening_index + 1, closing_index - 1)
+    local content_rope = util.rope_to_string(content)
+
+    local child = self.parser_functions.parse_inlines_full_link_and_image(content_rope)
+    
+    t[opening_index].rendered = {prefix, "[",child,"]", resolve_inline_link_closer(t, closing_index, false)}
+    delete_parsed_content_in_range(t, opening_index + 1, closing_index)
+  end
+
+%    \end{macrocode}
+% \begin{markdown}
+%
 % Resolve an inline link [a](b "c") from the delimiters at `opening_index` and `closing_index` within a delimiter table `t`.
 % Here, compared to other types of links, no reference definition is needed.
 %
@@ -26134,79 +26198,6 @@ function M.reader.new(writer, options)
 %    \end{macrocode}
 % \begin{markdown}
 %
-% Parse content between two delimiters in the delimiter table `t`. Produce the respective link and image 
-% macros and resolve potential dangling parentheses and attributes. 
-%
-% \end{markdown}
-%  \begin{macrocode}
-  local function render_link_or_image(t, opening_index, closing_index)
-    local link_r = t[opening_index].reference
-    local link_content_rope = t[opening_index].rope
-
-    local url = ""
-    if (link_r.url ~= nil) then
-      url = link_r.url
-    end
-
-    local title = ""
-    if (link_r.title ~= nil) then
-      title = link_r.title
-    end
-
-    local attributes = link_r.attributes
-
-    local mapped = self.parser_functions.parse_inlines_full_link_and_image(link_content_rope)
-
-    if attributes == nil or not next(attributes) then
-      attributes = nil
-    end
-
-    local rendered = {}
-    if (t[opening_index].element == "link") then
-      rendered = writer.link(mapped, url, title, attributes)
-    end
-
-    if (t[opening_index].element == "image") then
-      rendered = writer.image(mapped, url, title, attributes)
-    end
-
-    local mapped_parentheses = {}
-    if (t[closing_index].is_direct and t[opening_index].link_type ~= "inline") then
-      local resolved_closer = resolve_inline_link_closer(t, closing_index, false)
-      mapped_parentheses = self.parser_functions.parse_inlines_full_link_and_image(resolved_closer)
-    end
-
-    t[opening_index].rendered = { rendered, mapped_parentheses }
-    delete_parsed_content_in_range(t, opening_index + 1, closing_index)
-  end
-
-%    \end{macrocode}
-% \begin{markdown}
-%
-% Parse content between two delimiters in the delimiter table `t`. Enclose this content with literal brakcets and 
-% resolve potential dangling parentheses and attributes. 
-% In case of a image opening delimiter, an exclamation mark is also added before the brackets.
-%
-% \end{markdown}
-%  \begin{macrocode}
-  local function render_link_or_image_fallback(t, opening_index, closing_index)
-    local prefix = ""
-    if (t[opening_index].rendered) then
-      prefix = "!"
-    end
-
-    local content = collect_link_content(t, opening_index + 1, closing_index - 1)
-    local content_rope = util.rope_to_string(content)
-
-    local child = self.parser_functions.parse_inlines_full_link_and_image(content_rope)
-    
-    t[opening_index].rendered = {prefix, "[",child,"]", resolve_inline_link_closer(t, closing_index, false)}
-    delete_parsed_content_in_range(t, opening_index + 1, closing_index)
-  end
-
-%    \end{macrocode}
-% \begin{markdown}
-%
 % Parse a table of link and emphasis delimiters `delimiter_table`.
 % Iterate over the delimiters in the delimiter table `t` in two passes. First, the delimiters either 
 % marked as links (or images) with the `is_link` property, additionally assigned a closing delimiter. 
@@ -26232,7 +26223,7 @@ function M.reader.new(writer, options)
       local value = t[current_position]
 
       if not value.is_opening and value.type == "delimiter" and (value.element == "link" or value.element == "image") then
-        local opener_position, non_active_opener_position = find_opener(t, 1, current_position - 2)
+        local opener_position, non_active_opener_position = find_link_opener(t, 1, current_position - 2)
         local end_position = current_position
 
         if (opener_position ~= nil) then
@@ -26311,8 +26302,9 @@ function M.reader.new(writer, options)
       current_position = current_position + 1
     end
 
-    local emph_t = process_emphasis(t)
-    return emph_t
+    local emph_t = process_emphasis(t, 1, #t)
+    local final_result = collect_emphasis_content(t, 1, #t)
+    return final_result
   end
 
   function defer_link_and_emphasis_processing(delimiter_table)
@@ -26432,10 +26424,6 @@ function M.reader.new(writer, options)
                                             or writer.nbsp)
                   + parsers.spacechar^1 * parsers.optionalspace
                                         / writer.nbsp
-
-  parsers.Emph  = Ct( parsers.emph_open
-                    * (parsers.emph_content * parsers.emph_open_or_close)^1
-                    ) / process_emphasis
 
 %    \end{macrocode}
 % \par

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -1720,7 +1720,6 @@ local walkable_syntax = {
     "Str",
     "Space",
     "Endline",
-    "MaybeLinkAndEmph",
     "LinkAndEmph",
     "Code",
     "AutoLinkUrl",
@@ -4885,7 +4884,6 @@ be produced and contain the following text:
         "Str",
         "Space",
         "Endline",
-        "MaybeLinkAndEmph",
         "LinkAndEmph",
         "Code",
         "AutoLinkUrl",
@@ -26271,11 +26269,8 @@ end
                       = parsers.auto_link_relative_reference
                       / self.auto_link_url
 
-  parsers.MaybeLinkAndEmph = Ct(parsers.link_and_emph_table)
-                           / defer_link_and_emphasis_processing
-
-  parsers.LinkAndEmph     = Ct(parsers.link_and_emph_table)
-                          / process_links_and_emphasis
+  parsers.LinkAndEmph = Ct(parsers.link_and_emph_table)
+                      / defer_link_and_emphasis_processing
 
   parsers.EscapedChar   = parsers.backslash * C(parsers.escapable) / writer.string
 
@@ -26622,8 +26617,7 @@ end
         Space                 = parsers.Space,
         OptionalIndent        = parsers.OptionalIndent,
         Endline               = parsers.Endline,
-        MaybeLinkAndEmph      = parsers.MaybeLinkAndEmph,
-        LinkAndEmph           = parsers.fail,
+        LinkAndEmph           = parsers.LinkAndEmph,
         Code                  = parsers.Code,
         AutoLinkUrl           = parsers.AutoLinkUrl,
         AutoLinkEmail         = parsers.AutoLinkEmail,
@@ -26923,7 +26917,6 @@ end
     parsers.inlines_nbsp = Ct(inlines_nbsp_t)
 
     local inlines_no_link_or_emphasis_t = util.table_copy(inlines_t)
-    inlines_no_link_or_emphasis_t.MaybeLinkAndEmph = parsers.fail
     inlines_no_link_or_emphasis_t.LinkAndEmph = parsers.fail
     inlines_no_link_or_emphasis_t.EndlineExceptions = parsers.EndlineExceptionsInside
     parsers.inlines_no_link_or_emphasis = Ct(inlines_no_link_or_emphasis_t)
@@ -28292,13 +28285,9 @@ M.extensions.link_attributes = function()
 % \end{markdown}
 %  \begin{macrocode}
 
-      local MaybeLinkWithAttributesAndEmph  = Ct(parsers.link_and_emph_table * Cg(Cc(true), "match_link_attributes"))
-                                              / defer_link_and_emphasis_processing
+      local LinkWithAttributesAndEmph = Ct(parsers.link_and_emph_table * Cg(Cc(true), "match_link_attributes"))
+                                      / defer_link_and_emphasis_processing
 
-      local LinkWithAttributesAndEmph       = Ct(parsers.link_and_emph_table * Cg(Cc(true), "match_link_attributes"))
-                                            / process_links_and_emphasis
-
-      self.update_rule("MaybeLinkAndEmph", MaybeLinkWithAttributesAndEmph)
       self.update_rule("LinkAndEmph", LinkWithAttributesAndEmph)
 
 %    \end{macrocode}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -23846,7 +23846,7 @@ parsers.closeticks  = Cmt(C(parsers.backtick^1)
                           * Cb("ticks"), captures_equal_length)
 
 parsers.intickschar = (parsers.any - S("\n\r`"))
-                    + (parsers.newline * -parsers.blankline)
+                    + V("Endline")
                     + (parsers.backtick^1 - parsers.closeticks)
 
 local function process_inticks(s)
@@ -23859,7 +23859,7 @@ parsers.inticks = parsers.openticks
                 * C(parsers.space^0)
                 * parsers.closeticks
                 + parsers.openticks
-                * Cs(parsers.intickschar^0 / process_inticks)
+                * Cs(Cs(parsers.intickschar^0) / process_inticks)
                 * parsers.closeticks
 
 %    \end{macrocode}
@@ -23957,8 +23957,9 @@ parsers.link_text  = parsers.lbracket
                         + parsers.autolink
                         + ( parsers.backslash * parsers.backslash)
                         + ( parsers.backslash * (parsers.lbracket + parsers.rbracket)
-                          + parsers.any
-                          - (parsers.lbracket + parsers.rbracket + parsers.blankline^2)))^0)
+                          + V("Space") + V("Endline") 
+                          + (parsers.any
+                            - (parsers.newline + parsers.lbracket + parsers.rbracket + parsers.blankline^2))))^0)
                     * parsers.rbracket
 
 parsers.link_label  = parsers.lbracket
@@ -23969,8 +23970,9 @@ parsers.link_label  = parsers.lbracket
                         + parsers.autolink
                         + ( parsers.backslash * parsers.backslash)
                         + ( parsers.backslash * (parsers.lbracket + parsers.rbracket)
-                          + parsers.any
-                          - (parsers.lbracket + parsers.rbracket + parsers.blankline^2)))^1)
+                          + V("Space") + V("Endline") 
+                          + (parsers.any
+                            - (parsers.newline + parsers.lbracket + parsers.rbracket + parsers.blankline^2))))^1)
                     * parsers.rbracket
 
 -- url for markdown links, allowing nested brackets:
@@ -25287,14 +25289,12 @@ function M.reader.new(writer, options)
       else
         if value.type == "delimiter" and value.element == "emphasis" then
           if value.is_active then
-            content[#content + 1] = parse_content_part(content_part)
-            content_part = {}
-            content[#content + 1] = writer.escape(string.rep(value.character, value.current_count))
+            content_part[#content_part + 1] = string.rep(value.character, value.current_count)
           end
         else
           content_part[#content_part + 1] = value.content
-          value.content = ''
         end
+        value.content = ''
         value.is_active = false
       end
     end
@@ -25742,10 +25742,13 @@ function M.reader.new(writer, options)
 
   parsers.link_and_emph_content = Ct( Cg(Cc("content"), "type")
                                     * Cg(Cs(( parsers.link_emph_precedence 
-                                            + parsers.backslash^-1 * parsers.any
-                                            - parsers.blankline^2
-                                            - parsers.link_image_open_or_close 
-                                            - parsers.emph_open_or_close)^0), "content"))
+                                            + parsers.backslash * parsers.any
+                                            + V("Space")
+                                            + V("Endline") 
+                                            + (parsers.any - parsers.newline
+                                              - parsers.blankline^2
+                                              - parsers.link_image_open_or_close 
+                                              - parsers.emph_open_or_close))^0), "content"))
 
   parsers.link_and_emph_table = (parsers.link_image_opening + parsers.emph_open)
                               * parsers.link_and_emph_content
@@ -26172,10 +26175,6 @@ function M.reader.new(writer, options)
                      + parsers.headerstart
                      + parsers.html_interrupting
 
-  parsers.EndlineExceptionsInside
-                     = parsers.EndlineExceptions
-                     - parsers.eof
-
   parsers.Endline   = parsers.newline
                     * (parsers.check_minimal_indent 
                       * -V("EndlineExceptions") 
@@ -26193,14 +26192,9 @@ function M.reader.new(writer, options)
                                            / (options.hardLineBreaks
                                               and writer.hard_line_break
                                                or writer.space)
-                     + parsers.spacechar^1 * parsers.Endline^-1 * parsers.eof / self.expandtabs
                      + parsers.spacechar^1 * parsers.Endline
-                                           * parsers.optionalspace
-                                           / (options.hardLineBreaks
-                                              and writer.hard_line_break
-                                               or writer.space)
+                                           / writer.space
                      + parsers.spacechar^1 * -parsers.newline / self.expandtabs
-                     + parsers.spacechar^1 / ""
 
   parsers.NonbreakingEndline
                     = parsers.newline
@@ -26918,7 +26912,6 @@ end
 
     local inlines_no_link_or_emphasis_t = util.table_copy(inlines_t)
     inlines_no_link_or_emphasis_t.LinkAndEmph = parsers.fail
-    inlines_no_link_or_emphasis_t.EndlineExceptions = parsers.EndlineExceptionsInside
     parsers.inlines_no_link_or_emphasis = Ct(inlines_no_link_or_emphasis_t)
 %    \end{macrocode}
 % \par


### PR DESCRIPTION
This PR:
- joins the parsing of links and emphasis, fixing the precedence issues (see examples [520](https://spec.commonmark.org/0.30/#example-520),  [521](https://spec.commonmark.org/0.30/#example-521), and  [522](https://spec.commonmark.org/0.30/#example-522))
- simplifies link delimiter parsing -> one pass only, no recursive parsing
- fixes the handling of consecutive and trailing spacing -> inline spacing is preserved (see [652](https://spec.commonmark.org/0.30/#example-652)), needed for nested emphasis content
- removes the need for fallback with inline link destination and link attributes in general -> these are matched only once the link is successful (as example, this would previously not be parsed as emphasised link `*[[]()](*)`)
- adds missing `underscores` option to emphasis
- adds endline exceptions to links and code spans