### PR TITLE
Extension fixing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ DTXARCHIVE=markdown.dtx
 INSTALLER=markdown.ins docstrip.cfg
 TECHNICAL_DOCUMENTATION_RESOURCES=markdown.bib markdown-figure-block-diagram.tex \
   markdownthemewitiko_markdown_techdoc.sty
-TECHNICAL_DOCUMENTATION=markdown.pdf
+TECHNICAL_DOCUMENTATION=
 MARKDOWN_USER_MANUAL=markdown.md markdown.css
 HTML_USER_MANUAL=markdown.html markdown.css
 USER_MANUAL=$(MARKDOWN_USER_MANUAL) $(HTML_USER_MANUAL)

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -24836,23 +24836,27 @@ parsers.block_keyword =
     parsers.keyword_exact("track") +
     parsers.keyword_exact("ul")
 
-parsers.html_newline_indent = parsers.newline 
-                            * (parsers.check_minimal_blank_indent_and_any_trail * #parsers.blankline
-                              + parsers.check_minimal_indent_and_any_trail)
-
 -- end conditions
 parsers.html_blankline_end_condition  = parsers.linechar^0
-                                      * (parsers.html_newline_indent * parsers.linechar^1)^0
+                                      * ( parsers.newline 
+                                        * (parsers.check_minimal_blank_indent_and_any_trail 
+                                          * #parsers.blankline
+                                          + parsers.check_minimal_indent_and_any_trail) 
+                                        * parsers.linechar^1)^0
                                       * (parsers.newline^-1 / "")
 
+local function remove_trailing_blank_lines(s)
+  return s:gsub("[\n\r]+%s*$", "")
+end
+
 parsers.html_until_end = function(end_marker)
-  return  Cs((parsers.linechar - end_marker)^0
-            * (parsers.optionalspace * parsers.newline
-              * (parsers.check_minimal_blank_indent_and_any_trail 
-                * parsers.optionalspace * parsers.newline)^0
-              * parsers.check_minimal_indent_and_any_trail 
-              * ((parsers.linechar - end_marker)^1 + #end_marker))^0
-          * (parsers.linechar^0 * (parsers.newline^-1 / "")))
+  return Cs((parsers.newline 
+          * (parsers.check_minimal_blank_indent_and_any_trail 
+            * #parsers.blankline
+            + parsers.check_minimal_indent_and_any_trail)  
+          + parsers.linechar - end_marker)^0
+          * parsers.linechar^0 * parsers.newline^-1)
+         / remove_trailing_blank_lines
 end
 
 -- attributes
@@ -26771,13 +26775,14 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-  parsers.DisplayHtml = Cs(parsers.check_trail * (parsers.html_comment    
-                          + parsers.html_special_block 
-                          + parsers.html_block         
-                          + parsers.html_any_block     
-                          + parsers.html_instruction   
-                          + parsers.html_cdatasection  
-                          + parsers.html_declaration))
+  parsers.DisplayHtml = Cs(parsers.check_trail 
+                          * ( parsers.html_comment    
+                            + parsers.html_special_block 
+                            + parsers.html_block         
+                            + parsers.html_any_block     
+                            + parsers.html_instruction   
+                            + parsers.html_cdatasection  
+                            + parsers.html_declaration))
                         / writer.block_html_element
 
   parsers.indented_non_blank_line = parsers.indentedline - parsers.blankline

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -25714,11 +25714,8 @@ function M.reader.new(writer, options)
 %
 % \end{markdown}
 %  \begin{macrocode}
-  local function parse_content_part(t, i, content_part)
+  local function parse_content_part(content_part)
     local rope = util.rope_to_string(content_part)
-    if #t == i then
-      rope = rope:gsub("%s*$","") 
-    end
     local parsed = self.parser_functions.parse_inlines_no_link_or_emphasis(rope) 
     parsed.indent_info = nil
     return parsed
@@ -25739,7 +25736,7 @@ function M.reader.new(writer, options)
       local value = t[i]
 
       if value.rendered ~= nil then
-        content[#content + 1] = parse_content_part(t, i, content_part)
+        content[#content + 1] = parse_content_part(content_part)
         content_part = {}
         content[#content + 1] = value.rendered
         value.rendered = nil
@@ -25757,7 +25754,7 @@ function M.reader.new(writer, options)
     end
 
     if next(content_part) ~= nil then
-      content[#content + 1] = parse_content_part(t, closing_index, content_part)
+      content[#content + 1] = parse_content_part(content_part)
     end
 
     return content
@@ -26579,6 +26576,8 @@ function M.reader.new(writer, options)
       ::continue::
     end
 
+    t[#t].content = t[#t].content:gsub("%s*$","") 
+
     process_emphasis(t, 1, #t)
     local final_result = collect_emphasis_content(t, 1, #t)
     return final_result
@@ -26703,13 +26702,7 @@ function M.reader.new(writer, options)
                      + parsers.spacechar^1 * -parsers.newline / self.expandtabs
 
   parsers.NonbreakingEndline
-                    = parsers.newline
-                    * (parsers.check_minimal_indent 
-                      * -V("EndlineExceptions") 
-                      + parsers.check_optional_indent 
-                      * -V("EndlineExceptions") 
-                      * -parsers.starter)
-                    * parsers.spacechar^0
+                    = parsers.endline
                     / (options.hardLineBreaks 
                        and writer.hard_line_break
                         or writer.nbsp)

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -25148,8 +25148,8 @@ parsers.email_address_local_part_char = parsers.alphanumeric
 parsers.email_address_local_part = parsers.email_address_local_part_char^1
 
 parsers.email_address_dns_label = parsers.alphanumeric
-                                * ((parsers.alphanumeric + parsers.dash)^-62
-                                  * B(parsers.alphanumeric))^-1
+                                * (parsers.alphanumeric + parsers.dash)^-62
+                                * B(parsers.alphanumeric)
 
 parsers.email_address_domain  = parsers.email_address_dns_label
                               * (parsers.period * parsers.email_address_dns_label)^0
@@ -28711,6 +28711,10 @@ M.extensions.header_attributes = function()
                        * Cb("attributes")
                        / writer.heading
 
+      local function strip_trailing_spaces(s)
+        return s:gsub("%s*$","")
+      end
+
       local heading_line  = (parsers.linechar 
                             - (parsers.attributes
                               * parsers.optionalspace
@@ -28727,7 +28731,7 @@ M.extensions.header_attributes = function()
                                 * parsers.optionalspace
                                 * parsers.newline)^-1
                               * parsers.check_minimal_indent * parsers.check_trail * parsers.heading_level)
-                           * Ct(Cs(heading_text)
+                           * Ct(Cs(heading_text) / strip_trailing_spaces
                                 / self.parser_functions.parse_inlines )
                            * Cg(Ct((parsers.attributes
                                  * parsers.optionalspace

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -25714,9 +25714,12 @@ function M.reader.new(writer, options)
 %
 % \end{markdown}
 %  \begin{macrocode}
-  local function parse_content_part(content_part)
+  local function parse_content_part(t, i, content_part)
     local rope = util.rope_to_string(content_part)
-    local parsed = self.parser_functions.parse_inlines_no_link_or_emphasis(rope)
+    if #t == i then
+      rope = rope:gsub("%s*$","") 
+    end
+    local parsed = self.parser_functions.parse_inlines_no_link_or_emphasis(rope) 
     parsed.indent_info = nil
     return parsed
   end
@@ -25736,7 +25739,7 @@ function M.reader.new(writer, options)
       local value = t[i]
 
       if value.rendered ~= nil then
-        content[#content + 1] = parse_content_part(content_part)
+        content[#content + 1] = parse_content_part(t, i, content_part)
         content_part = {}
         content[#content + 1] = value.rendered
         value.rendered = nil
@@ -25754,7 +25757,7 @@ function M.reader.new(writer, options)
     end
 
     if next(content_part) ~= nil then
-      content[#content + 1] = parse_content_part(content_part)
+      content[#content + 1] = parse_content_part(t, closing_index, content_part)
     end
 
     return content
@@ -26200,11 +26203,18 @@ function M.reader.new(writer, options)
                                   + parsers.autolink
   end
 
+  parsers.link_and_emph_endline = parsers.newline
+                                * ((parsers.check_minimal_indent 
+                                  * -V("EndlineExceptions") 
+                                  + parsers.check_optional_indent 
+                                  * -V("EndlineExceptions") 
+                                  * -parsers.starter) / "")
+                                * parsers.spacechar^0 / "\n"
+
   parsers.link_and_emph_content = Ct( Cg(Cc("content"), "type")
                                     * Cg(Cs(( parsers.link_emph_precedence 
                                             + parsers.backslash * parsers.any
-                                            + V("Space")
-                                            + V("Endline") 
+                                            + parsers.link_and_emph_endline
                                             + (parsers.linechar
                                               - parsers.blankline^2
                                               - parsers.link_image_open_or_close 
@@ -26651,13 +26661,13 @@ function M.reader.new(writer, options)
 
   parsers.CodeEndlineExceptions = parsers.EndlineExceptions
 
-  parsers.endline   = parsers.newline
-                    * (parsers.check_minimal_indent 
-                      * -V("EndlineExceptions") 
-                      + parsers.check_optional_indent 
-                      * -V("EndlineExceptions") 
-                      * -parsers.starter)
-                    * parsers.spacechar^0
+  parsers.endline = parsers.newline
+                  * (parsers.check_minimal_indent
+                    * -V("EndlineExceptions")
+                    + parsers.check_optional_indent
+                    * -V("EndlineExceptions")
+                    * -parsers.starter)
+                  * parsers.spacechar^0
 
   parsers.Endline = parsers.endline
                   / (options.hardLineBreaks 
@@ -26678,20 +26688,18 @@ function M.reader.new(writer, options)
                             or writer.space)
 
   parsers.EndlineBreak = parsers.backslash * parsers.Endline
-                                           / (options.hardLineBreaks
-                                             and writer.hard_line_break
-                                               or writer.space)
+                                           / writer.hard_line_break
   
   parsers.OptionalIndent
                      = parsers.spacechar^1 / writer.space
 
   parsers.Space      = parsers.spacechar^2 * parsers.Endline
-                                           / (options.hardLineBreaks
-                                              and writer.hard_line_break
-                                               or writer.space)
+                                           / writer.hard_line_break
                      + parsers.spacechar^1 * parsers.Endline^-1 * parsers.eof / self.expandtabs
                      + parsers.spacechar^1 * parsers.Endline
-                                           / writer.space
+                                           / (options.hardLineBreaks
+                                             and writer.hard_line_break
+                                               or writer.space)
                      + parsers.spacechar^1 * -parsers.newline / self.expandtabs
 
   parsers.NonbreakingEndline
@@ -26708,9 +26716,7 @@ function M.reader.new(writer, options)
 
   parsers.NonbreakingSpace
                   = parsers.spacechar^2 * parsers.Endline 
-                                        / (options.hardLineBreaks
-                                           and writer.hard_line_break
-                                            or writer.nbsp)
+                                        / writer.hard_line_break
                   + parsers.spacechar^1 * parsers.Endline^-1 * parsers.eof / ""
                   + parsers.spacechar^1 * parsers.Endline
                                         * parsers.optionalspace
@@ -26958,14 +26964,6 @@ end
                      * Cb("level")
                      / writer.heading
 
-  local function remove_enclosing_whitespaces(o)
-    local heading_content = ""
-    for line in o:gmatch("([^\n]*)\n?") do
-      heading_content = heading_content .. (line:gsub("^%s*(.-)%s*$", "%1\n"))
-    end
-    return heading_content
-  end
-
   parsers.heading_line  = parsers.linechar^1
                         - parsers.thematic_break_lines
 
@@ -26976,7 +26974,7 @@ end
   parsers.SetextHeading = parsers.freeze_trail * parsers.check_trail_no_rem
                         * #(parsers.heading_text 
                            * parsers.check_minimal_indent * parsers.check_trail * parsers.heading_level)
-                        * Ct(Cs(parsers.heading_text) / remove_enclosing_whitespaces
+                        * Ct(Cs(parsers.heading_text)
                             / self.parser_functions.parse_inlines )
                         * parsers.check_minimal_indent_and_trail * parsers.heading_level
                         * parsers.newline
@@ -27425,6 +27423,7 @@ end
 
     local inlines_no_link_or_emphasis_t = util.table_copy(inlines_t)
     inlines_no_link_or_emphasis_t.LinkAndEmph = parsers.fail
+    inlines_no_link_or_emphasis_t.EndlineExceptions = parsers.EndlineExceptions - parsers.eof
     parsers.inlines_no_link_or_emphasis = Ct(inlines_no_link_or_emphasis_t)
 %    \end{macrocode}
 % \par
@@ -28729,14 +28728,6 @@ M.extensions.header_attributes = function()
                        * Cb("attributes")
                        / writer.heading
 
-      local function remove_enclosing_whitespaces(o)
-        local heading_content = ""
-        for line in o:gmatch("([^\n]*)\n?") do
-          heading_content = heading_content .. (line:gsub("^%s*(.-)%s*$", "%1\n"))
-        end
-        return heading_content
-      end
-
       local heading_line  = (parsers.linechar 
                             - (parsers.attributes
                               * parsers.optionalspace
@@ -28753,7 +28744,7 @@ M.extensions.header_attributes = function()
                                 * parsers.optionalspace
                                 * parsers.newline)^-1
                               * parsers.check_minimal_indent * parsers.check_trail * parsers.heading_level)
-                           * Ct(Cs(heading_text) / remove_enclosing_whitespaces
+                           * Ct(Cs(heading_text)
                                 / self.parser_functions.parse_inlines )
                            * Cg(Ct((parsers.attributes
                                  * parsers.optionalspace

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -24850,13 +24850,13 @@ local function remove_trailing_blank_lines(s)
 end
 
 parsers.html_until_end = function(end_marker)
-  return Cs((parsers.newline 
+  return Cs(Cs((parsers.newline 
           * (parsers.check_minimal_blank_indent_and_any_trail 
             * #parsers.blankline
             + parsers.check_minimal_indent_and_any_trail)  
           + parsers.linechar - end_marker)^0
           * parsers.linechar^0 * parsers.newline^-1)
-         / remove_trailing_blank_lines
+         / remove_trailing_blank_lines)
 end
 
 -- attributes
@@ -25085,10 +25085,8 @@ parsers.html_special_block  = parsers.html_blankline_ending_special_block
                             + parsers.html_closing_special_block
 
 -- parse html blocks
-parsers.html_block_opening  = (parsers.html_incomplete_open_tag
+parsers.html_block_opening  = parsers.html_incomplete_open_tag
                             + parsers.html_incomplete_close_tag
-                            - parsers.html_incomplete_open_special_tag
-                            - parsers.html_incomplete_close_special_tag)
 
 parsers.html_block  = parsers.html_block_opening
                     * parsers.html_blankline_end_condition

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -27127,7 +27127,7 @@ end
         Smart                 = parsers.Smart,
         Symbol                = parsers.Symbol,
         SpecialChar           = parsers.fail,
-        InitializeState       = parsers.succeed * Cg(Ct(""), "indent_info"), --temporary initialization
+        InitializeState       = parsers.succeed,
       }
 %    \end{macrocode}
 % \par
@@ -27221,6 +27221,15 @@ end
       syntax.InitializeState = syntax.InitializeState
                              * Cg(Ct("") / value, name)
     end
+%    \end{macrocode}
+% \par
+% \begin{markdown}
+%
+% Add a named group for indentation.
+%
+% \end{markdown}
+%  \begin{macrocode}
+    syntax.InitializeState = syntax.InitializeState * Cg(Ct(""), "indent_info")
 %    \end{macrocode}
 % \par
 % \begin{markdown}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -24843,12 +24843,17 @@ parsers.html_newline_indent = parsers.newline
 -- end conditions
 parsers.html_blankline_end_condition  = parsers.linechar^0
                                       * (parsers.html_newline_indent * parsers.linechar^1)^0
+                                      * (parsers.newline^-1 / "")
 
-parsers.html_empty_end_condition  = parsers.linechar^0
-                                  * (parsers.optionalspace * parsers.newline
-                                    * (parsers.check_minimal_blank_indent_and_any_trail 
-                                      * parsers.optionalspace * parsers.newline)^0
-                                    * parsers.check_minimal_indent_and_any_trail * parsers.linechar^1)^0
+parsers.html_until_end = function(end_marker)
+  return  Cs((parsers.linechar - end_marker)^0
+            * (parsers.optionalspace * parsers.newline
+              * (parsers.check_minimal_blank_indent_and_any_trail 
+                * parsers.optionalspace * parsers.newline)^0
+              * parsers.check_minimal_indent_and_any_trail 
+              * ((parsers.linechar - end_marker)^1 + #end_marker))^0
+          * (parsers.linechar^0 * (parsers.newline^-1 / "")))
+end
 
 -- attributes
 parsers.html_attribute_spacing  = parsers.optionalspace
@@ -24909,19 +24914,9 @@ parsers.html_comment_start = P("<!--")
 
 parsers.html_comment_end = P("-->")
 
-parsers.end_marker_condition = function(end_marker)
-  return Cs( parsers.newline 
-           * (parsers.check_minimal_blank_indent_and_any_trail * #parsers.blankline
-             + parsers.check_minimal_indent_and_any_trail)
-           + parsers.linechar - end_marker)^0
-         * end_marker
-         * parsers.linechar^0
-end
-
-parsers.html_comment = Cs(parsers.html_comment_start
-                         * Cs(parsers.end_marker_condition(parsers.html_comment_end)
-                             + Cs(parsers.html_empty_end_condition) * (parsers.newline^-1 / "")))
-
+parsers.html_comment = Cs( parsers.html_comment_start
+                         * parsers.html_until_end(parsers.html_comment_end))
+ 
 parsers.html_inline_comment = (parsers.html_comment_start / "")
                             * -P(">") * -P("->")
                             * Cs((V("Endline") + parsers.any - P("--") 
@@ -24932,10 +24927,9 @@ parsers.html_cdatasection_start = P("<![CDATA[")
 
 parsers.html_cdatasection_end = P("]]>")
 
-parsers.html_cdatasection = Cs(parsers.html_cdatasection_start
-                              * Cs(parsers.end_marker_condition(parsers.html_cdatasection_end)
-                                  + Cs(parsers.html_empty_end_condition) * (parsers.newline^-1 / "")))
-                            
+parsers.html_cdatasection = Cs( parsers.html_cdatasection_start
+                              * parsers.html_until_end(parsers.html_cdatasection_end))
+
 parsers.html_inline_cdatasection  = parsers.html_cdatasection_start
                                   * Cs(V("Endline") + parsers.any
                                       - parsers.nested_breaking_blank - parsers.html_cdatasection_end)^0
@@ -24945,9 +24939,8 @@ parsers.html_declaration_start = P("<!") * parsers.letter
 
 parsers.html_declaration_end = P(">")
 
-parsers.html_declaration  = Cs(parsers.html_declaration_start
-                              * Cs(parsers.end_marker_condition(parsers.html_declaration_end)
-                                  + Cs(parsers.html_empty_end_condition) * (parsers.newline^-1 / "")))
+parsers.html_declaration  = Cs( parsers.html_declaration_start
+                              * parsers.html_until_end(parsers.html_declaration_end))
 
 parsers.html_inline_declaration = parsers.html_declaration_start
                                 * Cs(V("Endline") + parsers.any 
@@ -24958,9 +24951,8 @@ parsers.html_instruction_start = P("<?")
 
 parsers.html_instruction_end = P("?>")
 
-parsers.html_instruction  = Cs(parsers.html_instruction_start
-                              * Cs(parsers.end_marker_condition(parsers.html_instruction_end)
-                                  + Cs(parsers.html_empty_end_condition) * (parsers.newline^-1 / "")))
+parsers.html_instruction  = Cs( parsers.html_instruction_start
+                              * parsers.html_until_end(parsers.html_instruction_end))
 
 parsers.html_inline_instruction = parsers.html_instruction_start
                                 * Cs(V("Endline") + parsers.any 
@@ -25072,23 +25064,18 @@ parsers.html_incomplete_blocks  = parsers.html_incomplete_open_tag
 
 -- parse special html blocks
 parsers.html_blankline_ending_special_block_opening = (parsers.html_close_special_tag
-                                                    + parsers.html_empty_special_tag)
+                                                      + parsers.html_empty_special_tag)
                                                     * #(parsers.optionalspace
                                                        * (parsers.newline + parsers.eof))
 
 parsers.html_blankline_ending_special_block = parsers.html_blankline_ending_special_block_opening
-                                            * parsers.html_blankline_end_condition * (parsers.newline^-1 / "")
+                                            * parsers.html_blankline_end_condition
 
 parsers.html_special_block_opening  = parsers.html_incomplete_open_special_tag
                                     - parsers.html_empty_special_tag
 
 parsers.html_closing_special_block  = parsers.html_special_block_opening
-                                    * ((parsers.html_newline_indent + 
-                                       parsers.linechar
-                                       - parsers.html_close_special_tag)^0
-                                      * parsers.html_close_special_tag
-                                      * parsers.linechar^0
-                                      + parsers.html_empty_end_condition)
+                                    * parsers.html_until_end(parsers.html_close_special_tag)
 
 parsers.html_special_block  = parsers.html_blankline_ending_special_block
                             + parsers.html_closing_special_block
@@ -25100,7 +25087,7 @@ parsers.html_block_opening  = (parsers.html_incomplete_open_tag
                             - parsers.html_incomplete_close_special_tag)
 
 parsers.html_block  = parsers.html_block_opening
-                    * parsers.html_blankline_end_condition * (parsers.newline^-1 / "")
+                    * parsers.html_blankline_end_condition
 
 -- parse any html blocks
 parsers.html_any_block_opening  = (parsers.html_any_open_tag
@@ -25109,7 +25096,7 @@ parsers.html_any_block_opening  = (parsers.html_any_open_tag
                                 * #(parsers.optionalspace * (parsers.newline + parsers.eof))
 
 parsers.html_any_block  = parsers.html_any_block_opening
-                        * parsers.html_blankline_end_condition * (parsers.newline^-1 / "")
+                        * parsers.html_blankline_end_condition
 
 parsers.html_inline_comment_full  = parsers.html_comment_start
                                   * -P(">") * -P("->")

--- a/tests/testfiles/CommonMark_0.30/backslash_escapes/005.test
+++ b/tests/testfiles/CommonMark_0.30/backslash_escapes/005.test
@@ -10,4 +10,5 @@ foo\
 bar
 >>>
 documentBegin
+hardLineBreak
 documentEnd

--- a/tests/testfiles/CommonMark_0.30/hard_line_breaks/001.test
+++ b/tests/testfiles/CommonMark_0.30/hard_line_breaks/001.test
@@ -10,4 +10,5 @@ foo
 baz
 >>>
 documentBegin
+hardLineBreak
 documentEnd

--- a/tests/testfiles/CommonMark_0.30/hard_line_breaks/002.test
+++ b/tests/testfiles/CommonMark_0.30/hard_line_breaks/002.test
@@ -10,4 +10,5 @@ foo\
 baz
 >>>
 documentBegin
+hardLineBreak
 documentEnd

--- a/tests/testfiles/CommonMark_0.30/hard_line_breaks/003.test
+++ b/tests/testfiles/CommonMark_0.30/hard_line_breaks/003.test
@@ -10,4 +10,5 @@ foo
 baz
 >>>
 documentBegin
+hardLineBreak
 documentEnd

--- a/tests/testfiles/CommonMark_0.30/hard_line_breaks/004.test
+++ b/tests/testfiles/CommonMark_0.30/hard_line_breaks/004.test
@@ -10,4 +10,5 @@ foo
      bar
 >>>
 documentBegin
+hardLineBreak
 documentEnd

--- a/tests/testfiles/CommonMark_0.30/hard_line_breaks/005.test
+++ b/tests/testfiles/CommonMark_0.30/hard_line_breaks/005.test
@@ -10,4 +10,5 @@ foo\
      bar
 >>>
 documentBegin
+hardLineBreak
 documentEnd

--- a/tests/testfiles/CommonMark_0.30/hard_line_breaks/006.test
+++ b/tests/testfiles/CommonMark_0.30/hard_line_breaks/006.test
@@ -10,5 +10,5 @@
 bar*
 >>>
 documentBegin
-emphasis: foo bar
+emphasis: foo(hardLineBreak)bar
 documentEnd

--- a/tests/testfiles/CommonMark_0.30/hard_line_breaks/007.test
+++ b/tests/testfiles/CommonMark_0.30/hard_line_breaks/007.test
@@ -10,5 +10,5 @@
 bar*
 >>>
 documentBegin
-emphasis: foo bar
+emphasis: foo(hardLineBreak)bar
 documentEnd

--- a/tests/testfiles/CommonMark_0.30/paragraphs/008.test
+++ b/tests/testfiles/CommonMark_0.30/paragraphs/008.test
@@ -11,5 +11,6 @@
 >>>
 documentBegin
 emphasis: aaa
+hardLineBreak
 emphasis: bbb
 documentEnd

--- a/tests/testfiles/lunamark-markdown/hard-line-breaks.test
+++ b/tests/testfiles/lunamark-markdown/hard-line-breaks.test
@@ -1,0 +1,22 @@
+\def\markdownOptionHardLineBreaks{true}
+<<<
+This test ensures that the Lua `hardLineBreaks` option correctly propagates
+through the plain TeX interface.
+
+'Twas *brillig*, and the slithy toves
+Did *gyre and gimble* in the wabe; 
+All mimsy were the *borogoves*,  
+And the mome raths *outgrabe*.
+>>>
+documentBegin
+codeSpan: hardLineBreaks
+hardLineBreak
+interblockSeparator
+emphasis: brillig
+hardLineBreak
+emphasis: gyre and gimble
+hardLineBreak
+emphasis: borogoves
+hardLineBreak
+emphasis: outgrabe
+documentEnd

--- a/tests/testfiles/lunamark-markdown/no-tex-comments.test
+++ b/tests/testfiles/lunamark-markdown/no-tex-comments.test
@@ -14,5 +14,5 @@ interblockSeparator
 emphasis: emphasi(percentSign)  this is a comment zed text
 emphasis: emphasi(percentSign)  another one zed text
 interblockSeparator
-emphasis: end of  a line
+emphasis: end of (hardLineBreak)a line
 documentEnd

--- a/tests/testfiles/lunamark-markdown/tex-comments.test
+++ b/tests/testfiles/lunamark-markdown/tex-comments.test
@@ -40,11 +40,11 @@ emphasis: emphasi(percentSign)  another one zed text
 interblockSeparator
 interblockSeparator
 interblockSeparator
-emphasis: end of  a line
+emphasis: end of (hardLineBreak)a line
 interblockSeparator
 emphasis: end of (backslash) a line
 interblockSeparator
-emphasis: end of (backslash) a line
+emphasis: end of (backslash)(hardLineBreak)a line
 interblockSeparator
 codeSpan: (backslash)
 codeSpan: (backslash)(percentSign)


### PR DESCRIPTION
This PR:
- restores the `hardLineBreak` macro
- parses HTML end conditions in one pass
- moves indentation initialization